### PR TITLE
fix: inconsistent formatting in prompts

### DIFF
--- a/doc/prompt_generator.md
+++ b/doc/prompt_generator.md
@@ -12,7 +12,7 @@ The prompt generator is a powerful feature in the Prompt Builder that helps you 
 
 The backend uses a meta prompt that enforces these guidelines. Here's the prompt:
 
-```
+```md
 Given a task description or existing prompt, produce a detailed system prompt to guide a language model in completing the task effectively.
 
 # Guidelines
@@ -20,17 +20,17 @@ Given a task description or existing prompt, produce a detailed system prompt to
 - Understand the Task: Grasp the main objective, goals, requirements, constraints, and expected output.
 - Minimal Changes: If an existing prompt is provided, improve it only if it's simple. For complex prompts, enhance clarity and add missing elements without altering the original structure.
 - Reasoning Before Conclusions**: Encourage reasoning steps before any conclusions are reached. ATTENTION! If the user provides examples where the reasoning happens afterward, REVERSE the order! NEVER START EXAMPLES WITH CONCLUSIONS!
-    - Reasoning Order: Call out reasoning portions of the prompt and conclusion parts (specific fields by name). For each, determine the ORDER in which this is done, and whether it needs to be reversed.
-    - Conclusion, classifications, or results should ALWAYS appear last.
+  - Reasoning Order: Call out reasoning portions of the prompt and conclusion parts (specific fields by name). For each, determine the ORDER in which this is done, and whether it needs to be reversed.
+  - Conclusion, classifications, or results should ALWAYS appear last.
 - Examples: Include high-quality examples if helpful, using placeholders [in brackets] for complex elements.
-   - What kinds of examples may need to be included, how many, and whether they are complex enough to benefit from placeholders.
+  - What kinds of examples may need to be included, how many, and whether they are complex enough to benefit from placeholders.
 - Clarity and Conciseness: Use clear, specific language. Avoid unnecessary instructions or bland statements.
 - Formatting: Use markdown features for readability. DO NOT USE \`\`\` CODE BLOCKS UNLESS SPECIFICALLY REQUESTED.
 - Preserve User Content: If the input task or prompt includes extensive guidelines or examples, preserve them entirely, or as closely as possible. If they are vague, consider breaking down into sub-steps. Keep any details, guidelines, examples, variables, or placeholders provided by the user.
 - Constants: DO include constants in the prompt, as they are not susceptible to prompt injection. Such as guides, rubrics, and examples.
 - Output Format: Explicitly the most appropriate output format, in detail. This should include length and syntax (e.g. short sentence, paragraph, JSON, etc.)
-    - For tasks outputting well-defined or structured data (classification, JSON, etc.) bias toward outputting a JSON.
-    - JSON should never be wrapped in code blocks (\`\`\`) unless explicitly requested.
+  - For tasks outputting well-defined or structured data (classification, JSON, etc.) bias toward outputting a JSON.
+  - JSON should never be wrapped in code blocks (\`\`\`) unless explicitly requested.
 
 The final prompt you output should adhere to the following structure below. Do not include any additional commentary, only output the completed system prompt. SPECIFICALLY, do not include any additional messages at the start or end of the prompt. (e.g. no "---")
 

--- a/prompt/prompt-generator.prompt
+++ b/prompt/prompt-generator.prompt
@@ -5,17 +5,17 @@ Given a task description or existing prompt, produce a detailed system prompt to
 - Understand the Task: Grasp the main objective, goals, requirements, constraints, and expected output.
 - Minimal Changes: If an existing prompt is provided, improve it only if it's simple. For complex prompts, enhance clarity and add missing elements without altering the original structure.
 - Reasoning Before Conclusions**: Encourage reasoning steps before any conclusions are reached. ATTENTION! If the user provides examples where the reasoning happens afterward, REVERSE the order! NEVER START EXAMPLES WITH CONCLUSIONS!
-    - Reasoning Order: Call out reasoning portions of the prompt and conclusion parts (specific fields by name). For each, determine the ORDER in which this is done, and whether it needs to be reversed.
-    - Conclusion, classifications, or results should ALWAYS appear last.
+  - Reasoning Order: Call out reasoning portions of the prompt and conclusion parts (specific fields by name). For each, determine the ORDER in which this is done, and whether it needs to be reversed.
+  - Conclusion, classifications, or results should ALWAYS appear last.
 - Examples: Include high-quality examples if helpful, using placeholders [in brackets] for complex elements.
-   - What kinds of examples may need to be included, how many, and whether they are complex enough to benefit from placeholders.
+  - What kinds of examples may need to be included, how many, and whether they are complex enough to benefit from placeholders.
 - Clarity and Conciseness: Use clear, specific language. Avoid unnecessary instructions or bland statements.
 - Formatting: Use markdown features for readability. DO NOT USE \`\`\` CODE BLOCKS UNLESS SPECIFICALLY REQUESTED.
 - Preserve User Content: If the input task or prompt includes extensive guidelines or examples, preserve them entirely, or as closely as possible. If they are vague, consider breaking down into sub-steps. Keep any details, guidelines, examples, variables, or placeholders provided by the user.
 - Constants: DO include constants in the prompt, as they are not susceptible to prompt injection. Such as guides, rubrics, and examples.
 - Output Format: Explicitly the most appropriate output format, in detail. This should include length and syntax (e.g. short sentence, paragraph, JSON, etc.)
-    - For tasks outputting well-defined or structured data (classification, JSON, etc.) bias toward outputting a JSON.
-    - JSON should never be wrapped in code blocks (\`\`\`) unless explicitly requested.
+  - For tasks outputting well-defined or structured data (classification, JSON, etc.) bias toward outputting a JSON.
+  - JSON should never be wrapped in code blocks (\`\`\`) unless explicitly requested.
 
 The final prompt you output should adhere to the following structure below. Do not include any additional commentary, only output the completed system prompt. SPECIFICALLY, do not include any additional messages at the start or end of the prompt. (e.g. no "---")
 

--- a/prompt/test-data-generator.prompt
+++ b/prompt/test-data-generator.prompt
@@ -1,9 +1,9 @@
 <Prompt Template>
 {{{inputPrompt}}}
 </Prompt Template>
-    
+
 Your job is to construct a test case for the prompt template above. This template contains "variables", which are placeholders to be filled in later. In this case, the variables are:
-    
+
 <variables>
 {{#variableKeys}}
 {{{.}}}
@@ -13,7 +13,7 @@ Your job is to construct a test case for the prompt template above. This templat
 {{#examples.0.0}}
 Here are the example test cases provided by the user.
 <examples>
-{{#examples}} 
+{{#examples}}
 <example>
 <variables>
 {{#.}}
@@ -26,10 +26,10 @@ Here are the example test cases provided by the user.
 {{/examples.0.0}}
 
 First, in <planning> tags, do the following:
-    
+
 1. Summarize the prompt template. What is the goal of the user who created it?
 2. For each variable in <variables>, carefully consider what a paradigmatic, realistic example of that variable would look like. You'll want to note who will be responsible "in prod" for supplying values. Written by a human "end user"? Downloaded from a website? Extracted from a database? Think about things like length, format, and tone in addition to semantic content. Use the examples provided by the user to guide this exercise. The goal is to acquire a sense of the statistical distribution the examples are being drawn from. The example you write should be drawn from that same distribution, but sufficiently different from the examples that it provides additional signal. A tricky balancing act, but I have faith in you.
-    
+
 Once you're done, output a test case for this prompt template with a full, complete, value for each variable. The output format should consist of a tagged block for each variable, with the value inside the block, like the below:
 
 <planning>


### PR DESCRIPTION
Standardize markdown formatting across the project for consistency.

- 3 spaces at https://github.com/microsoft/vscode-ai-toolkit/blob/c2d1ec927d98b386b5f8a204ffa4ad4567a062b2/prompt/prompt-generator.prompt#L11
- lists used 4 instead of 2 spaces
- removed trailing spaces