### PR TITLE
adding note on GLIBC Tracing tool dependency issue for Linux users

### DIFF
--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -12,6 +12,9 @@ All frameworks or SDKs that support OTLP and follow [semantic conventions for ge
 > 1. The SDKs in brackets are third-party SDKs to support OTLP instrumentation. They are used because the official SDKs don't support OTLP.
 > 2. These instrumentation SDKs don't strictly adhere to the OpenTelemetry semantic conventions for generative AI systems.
 
+> [!IMPORTANT]
+> For **Tracing** tool to be enabled on Linux OS the version of GLIBC (GNU C Library) needs to be version 2.39+ (check with `ldd --version`) - this corresponds to **Ubuntu 24.04 Noble** or **Debian 13 Trixie**
+
 ## How to Get Started with Tracing
 
 1. Select **Tracing** in the tree view to open the tracing webview and click **Start Collector** button to start the local OTLP trace collector server.


### PR DESCRIPTION
This provides a note on the Tracing document that alerts users on Linux that the version of GLIBC and the related Linux Distro like Ubuntu 24.04/Noble and Debian 13/Trixie are currently needed with glibc version 2.39+


Related issues
https://github.com/microsoft/vscode-ai-toolkit/issues/313 
https://github.com/microsoft/vscode-ai-toolkit/issues/302


<img width="1622" height="310" alt="image" src="https://github.com/user-attachments/assets/0aa971c9-713d-41e9-9acd-2b46f2bb78b8" />
