### PR TITLE
ci: bootstrap sample-catalog sync workflow

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -1,0 +1,841 @@
+// @ts-check
+/**
+ * Generate samples/hosted-agent/sample-catalog.json from the foundry-samples repository.
+ *
+ * Walks the hosted-agents tree in microsoft-foundry/foundry-samples once via
+ * the git-tree API, parses each sample's agent.yaml (+ optional
+ * agent.manifest.yaml) for protocol and model requirements, derives
+ * displayName from the directory name, and — when AZURE_OPENAI_* secrets are
+ * set — fills the description with a short LLM-generated sentence sourced
+ * from the sample's README.md.
+ *
+ * Usage:
+ *   node generate_sample_catalog.mjs <commitSha>
+ *
+ * Environment variables:
+ *   GITHUB_TOKEN        Optional GitHub token for API authentication.
+ *   REPO_ROOT           Repository root (defaults to two levels up from this script).
+ *   SAMPLES_REPO_URL    Source repo URL (defaults to https://github.com/microsoft-foundry/foundry-samples/).
+ *   AZURE_OPENAI_*      Optional; when set, descriptions are LLM-generated.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, appendFileSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const REPO_ROOT = process.env.REPO_ROOT || resolve(__dirname, '..', '..');
+const SAMPLES_REPO_URL = process.env.SAMPLES_REPO_URL || 'https://github.com/microsoft-foundry/foundry-samples/';
+const SAMPLES_REPO_API = 'https://api.github.com/repos/microsoft-foundry/foundry-samples';
+const OUTPUT_PATH = join(REPO_ROOT, 'samples', 'hosted-agent', 'sample-catalog.json');
+const OVERRIDES_PATH = join(REPO_ROOT, 'samples', 'hosted-agent', 'sample-overrides.json');
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN || '';
+
+const LANGUAGES = ['python', 'csharp'];
+const FRAMEWORKS = ['agent-framework', 'bring-your-own'];
+
+/** @type {Record<string, {title: string, placeholder: string, options: Record<string, string>}>} */
+const DIMENSION_DEFAULTS = {
+    language: {
+        title: 'Select a Language',
+        placeholder: 'Choose the language for your agent',
+        options: {
+            python: 'Python',
+            csharp: 'C# (.NET)',
+        },
+    },
+    framework: {
+        title: 'Select a Framework',
+        placeholder: 'Choose the framework for your agent',
+        // Insertion order here drives the option order in the generated catalog
+        // (see buildDimensions). Keep the most actively promoted framework first.
+        options: {
+            'copilot-sdk': 'Copilot SDK',
+            'agent-framework': 'Agent Framework',
+            'bring-your-own': 'Bring Your Own',
+        },
+    },
+    protocol: {
+        title: 'Select a Protocol',
+        placeholder: 'Choose the protocol for your agent',
+        options: {
+            responses: 'Responses API',
+            invocations: 'Invocations API',
+        },
+    },
+};
+
+const TEMPLATE_SELECTION = {
+    title: 'Select a Template',
+    placeholder: 'Choose a template for your agent',
+};
+
+// Path segments must be alphanumeric, hyphens, underscores, or dots
+const SAFE_PATH_SEGMENT = /^[a-zA-Z0-9._-]+$/;
+
+/**
+ * Collected anomaly messages surfaced in CI step summary so reviewers do not
+ * silently merge a catalog with missing/derived data. Always populated, even
+ * when running locally without a step-summary file.
+ * @type {string[]}
+ */
+const warnings = [];
+
+/**
+ * Record a warning that should appear in the CI step summary, and mirror it
+ * to stderr for live log visibility.
+ * @param {string} message
+ */
+function warn(message) {
+    warnings.push(message);
+    console.warn(`WARN: ${message}`);
+}
+
+/**
+ * @param {string} url
+ * @returns {Promise<any>}
+ */
+async function fetchJson(url) {
+    /** @type {Record<string, string>} */
+    const headers = {
+        'User-Agent': 'microsoft-foundry-for-vscode-sync',
+        Accept: 'application/vnd.github+json',
+    };
+    if (GITHUB_TOKEN) {
+        headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+    }
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status} for ${url}`);
+    }
+    return response.json();
+}
+
+/**
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+async function fetchText(url) {
+    /** @type {Record<string, string>} */
+    const headers = { 'User-Agent': 'microsoft-foundry-for-vscode-sync' };
+    if (GITHUB_TOKEN) {
+        headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+    }
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status} for ${url}`);
+    }
+    return response.text();
+}
+
+/**
+ * Validate that a path segment is safe: no traversal, no special chars, no
+ * leading-dot directories (e.g. `.claude`, `.github`) which are tooling
+ * metadata, not sample templates.
+ * @param {string} segment
+ * @returns {boolean}
+ */
+function isSafePathSegment(segment) {
+    if (segment === '.' || segment === '..' || segment.startsWith('.')) {
+        return false;
+    }
+    return SAFE_PATH_SEGMENT.test(segment);
+}
+
+/**
+ * Parse the commit SHA from the CLI argument.
+ * @returns {string}
+ */
+function parseCommitShaArg() {
+    const sha = process.argv[2] || '';
+    if (!sha) {
+        console.error('Usage: node generate_sample_catalog.mjs <commitSha>');
+        process.exit(1);
+    }
+    if (!/^[0-9a-f]{7,40}$/i.test(sha)) {
+        throw new Error(`Invalid commit SHA: "${sha}"`);
+    }
+    return sha;
+}
+
+/**
+ * Fetch the full recursive git tree for a ref. One API call covers the entire
+ * `samples/` hierarchy, which is much cheaper (and more accurate) than walking
+ * the `/contents/` endpoint level-by-level — and it lets us discover samples
+ * at arbitrary nesting depths (e.g. `bring-your-own/voicelive/<template>`)
+ * without hard-coding the layout.
+ *
+ * @param {string} ref
+ * @returns {Promise<{tree: Array<{path: string, type: string}>, truncated: boolean}>}
+ */
+async function fetchRepoTree(ref) {
+    const data = await fetchJson(`${SAMPLES_REPO_API}/git/trees/${ref}?recursive=1`);
+    const tree = Array.isArray(data?.tree) ? data.tree : [];
+    return { tree, truncated: Boolean(data?.truncated) };
+}
+
+/**
+ * Find sample template directories under a `hosted-agents/<framework>/` prefix.
+ * A template is identified by the presence of an `agent.yaml`. When nested
+ * agent.yaml files exist (e.g. a sub-agent declared inside a parent sample),
+ * only the OUTERMOST one is treated as a catalog template — the inner files
+ * are part of the parent sample. Hidden directories (segments beginning with
+ * `.`, e.g. `.claude/skills`) are skipped, as are segments that fail the
+ * `SAFE_PATH_SEGMENT` check.
+ *
+ * @param {Array<{path: string, type: string}>} tree
+ * @param {string} prefix Path prefix ending in `/`, e.g. `samples/python/hosted-agents/agent-framework/`.
+ * @returns {string[]} Repo-relative template directory paths, outermost only.
+ */
+function findTemplateDirsUnder(tree, prefix) {
+    const candidates = tree
+        .filter((entry) => entry.type === 'blob' && entry.path.startsWith(prefix) && entry.path.endsWith('/agent.yaml'))
+        .map((entry) => entry.path.slice(0, -'/agent.yaml'.length))
+        .filter((dir) => {
+            const rel = dir.slice(prefix.length);
+            if (!rel) {
+                return false;
+            }
+            return rel.split('/').every((seg) => isSafePathSegment(seg));
+        })
+        // Lexicographic sort serves two purposes: (1) a parent path always
+        // sorts before its descendants, so the `startsWith` check below
+        // correctly keeps only the outermost agent.yaml; (2) it preserves
+        // upstream's `NN-` numeric prefix ordering in the picker.
+        .sort();
+
+    /** @type {string[]} */
+    const outermost = [];
+    for (const dir of candidates) {
+        if (!outermost.some((existing) => dir.startsWith(`${existing}/`))) {
+            outermost.push(dir);
+        }
+    }
+    return outermost;
+}
+
+/**
+ * Infer protocol when `agent.yaml` does not declare one explicitly. Looks for
+ * a `responses` or `invocations` segment in the path, then for the substring
+ * in the leaf directory name (common for samples like
+ * `hello-world-invocations-voicelive`). Falls back to `responses` and emits a
+ * warning so the catalog reviewer can verify the choice.
+ *
+ * @param {string} templatePath
+ * @returns {'responses' | 'invocations'}
+ */
+function inferProtocolFromPath(templatePath) {
+    const segments = templatePath.split('/');
+    if (segments.includes('responses')) {
+        return 'responses';
+    }
+    if (segments.includes('invocations')) {
+        return 'invocations';
+    }
+    const leaf = segments[segments.length - 1].toLowerCase();
+    if (leaf.includes('invocations')) {
+        return 'invocations';
+    }
+    if (leaf.includes('responses')) {
+        return 'responses';
+    }
+    warn(`Could not infer protocol for "${templatePath}"; defaulting to "responses". Add a "- protocol:" entry to agent.yaml or a sample-overrides.json entry to silence this.`);
+    return 'responses';
+}
+
+/**
+ * Minimal parser for agent.yaml. Extracts the declared protocol(s) and
+ * whether the sample exposes the AZURE_AI_MODEL_DEPLOYMENT_NAME env var
+ * (used as a heuristic for `requiresModel`). Does NOT use eval or a real
+ * YAML library — a regex-y scan is sufficient for our two fields.
+ * @param {string} content
+ * @returns {{ protocols: Array<'responses' | 'invocations'>, hasModelEnv: boolean }}
+ */
+function parseAgentYaml(content) {
+    /** @type {{ protocols: Array<'responses' | 'invocations'>, hasModelEnv: boolean }} */
+    const result = { protocols: [], hasModelEnv: false };
+
+    for (const line of content.split('\n')) {
+        const stripped = line.trim();
+        if (stripped.startsWith('- protocol:')) {
+            const value = stripped.split(':')[1]?.trim();
+            if (value === 'responses' || value === 'invocations') {
+                result.protocols.push(value);
+            }
+        }
+        if (stripped.startsWith('- name:') && stripped.includes('AZURE_AI_MODEL_DEPLOYMENT_NAME')) {
+            result.hasModelEnv = true;
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Fetch and parse agent.yaml for a sample directory.
+ * @param {string} samplePath
+ * @param {string} ref
+ * @returns {Promise<{ protocols: Array<'responses' | 'invocations'>, hasModelEnv: boolean } | null>}
+ */
+async function fetchAgentYaml(samplePath, ref) {
+    const rawUrl = `https://raw.githubusercontent.com/microsoft-foundry/foundry-samples/${ref}/${samplePath}/agent.yaml`;
+    try {
+        const content = await fetchText(rawUrl);
+        return parseAgentYaml(content);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Minimal parser for agent.manifest.yaml — detects whether the manifest
+ * declares a top-level `resources:` list containing `kind: model`. Matches
+ * both `- kind: model` and the multi-line continuation form, and limits
+ * scanning to the `resources:` block to avoid false positives.
+ * @param {string} content
+ * @returns {{ hasModelResource: boolean }}
+ */
+function parseAgentManifestYaml(content) {
+    let inResources = false;
+    for (const rawLine of content.split('\n')) {
+        const stripped = rawLine.trim();
+        // Detect top-level key (column 0, e.g. `resources:`, `metadata:`).
+        if (/^[A-Za-z_][\w-]*:/.test(rawLine)) {
+            inResources = stripped.startsWith('resources:');
+            continue;
+        }
+        if (!inResources) {
+            continue;
+        }
+        // Strip optional `- ` so the inline and continuation forms both match.
+        const withoutDash = stripped.replace(/^-\s+/, '');
+        if (withoutDash.startsWith('kind:')) {
+            const value = withoutDash.substring('kind:'.length).trim().replace(/^["']|["']$/g, '');
+            if (value === 'model') {
+                return { hasModelResource: true };
+            }
+        }
+    }
+    return { hasModelResource: false };
+}
+
+/**
+ * Fetch and parse agent.manifest.yaml for a sample directory.
+ * @param {string} samplePath
+ * @param {string} ref
+ * @returns {Promise<{ hasModelResource: boolean } | null>}
+ */
+async function fetchAgentManifestYaml(samplePath, ref) {
+    const rawUrl = `https://raw.githubusercontent.com/microsoft-foundry/foundry-samples/${ref}/${samplePath}/agent.manifest.yaml`;
+    try {
+        const content = await fetchText(rawUrl);
+        return parseAgentManifestYaml(content);
+    } catch {
+        return null;
+    }
+}
+
+// Azure OpenAI configuration (from GitHub Secrets via env vars)
+const AZURE_OPENAI_ENDPOINT = process.env.AZURE_OPENAI_ENDPOINT || '';
+const AZURE_OPENAI_API_KEY = process.env.AZURE_OPENAI_API_KEY || '';
+const AZURE_OPENAI_DEPLOYMENT = process.env.AZURE_OPENAI_DEPLOYMENT || 'gpt-4o-mini';
+
+/**
+ * Fetch README.md content for a sample directory.
+ * @param {string} samplePath
+ * @param {string} ref
+ * @returns {Promise<string | null>}
+ */
+async function fetchReadme(samplePath, ref) {
+    const rawUrl = `https://raw.githubusercontent.com/microsoft-foundry/foundry-samples/${ref}/${samplePath}/README.md`;
+    try {
+        return await fetchText(rawUrl);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Call Azure OpenAI to generate a description from README content. We
+ * intentionally do NOT ask the LLM for displayName — the folder name (with
+ * numeric-prefix stripped, dashes turned into spaces, and Title Case)
+ * produces more consistent results across the catalog and is easier for PMs
+ * to predict at review time.
+ *
+ * @param {string} readmeContent
+ * @param {string} samplePath
+ * @returns {Promise<{ description: string } | null>}
+ */
+async function generateWithLLM(readmeContent, samplePath) {
+    if (!AZURE_OPENAI_ENDPOINT || !AZURE_OPENAI_API_KEY) {
+        return null;
+    }
+
+    const apiUrl = `${AZURE_OPENAI_ENDPOINT}/openai/deployments/${AZURE_OPENAI_DEPLOYMENT}/chat/completions?api-version=2024-08-01-preview`;
+
+    const systemPrompt = `You generate one-sentence descriptions for a VS Code template picker.
+The user has already selected language, framework, and protocol before seeing these items, so the description must NOT repeat those choices.
+
+Rules:
+- One sentence, max 100 characters
+- Plain text, no markdown
+- Describe what the sample does, not how it is implemented
+- Do NOT include language names, protocol names, framework names, or words like "Sample" / "Demo"
+
+Examples:
+  {"description": "Minimal agent that echoes a response from a Foundry model."}
+  {"description": "Conversational agent with multi-turn session history."}
+  {"description": "Agent with local function tools for hotel search."}
+  {"description": "Agent that discovers and invokes tools from a remote MCP server."}
+  {"description": "Agent that saves and retrieves notes using function calling."}
+
+Respond ONLY with a JSON object: {"description": "..."}`;
+
+    const userPrompt = `Path: ${samplePath}
+
+README.md:
+${readmeContent.substring(0, 2000)}`;
+
+    const body = {
+        messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+        ],
+        temperature: 0,
+        max_tokens: 120,
+    };
+
+    try {
+        const response = await fetch(apiUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'api-key': AZURE_OPENAI_API_KEY,
+            },
+            body: JSON.stringify(body),
+        });
+
+        if (!response.ok) {
+            warn(`LLM API returned ${response.status} for ${samplePath}; description will be left empty.`);
+            return null;
+        }
+
+        const data = await response.json();
+        const content = data.choices?.[0]?.message?.content?.trim();
+        if (!content) {
+            return null;
+        }
+
+        // Parse JSON response — strip markdown code fences if present
+        const jsonStr = content.replace(/^```json\s*/, '').replace(/\s*```$/, '');
+        const parsed = JSON.parse(jsonStr);
+
+        const description = typeof parsed.description === 'string' ? parsed.description.trim() : '';
+        if (!description) {
+            return null;
+        }
+
+        return { description };
+    } catch (/** @type {any} */ err) {
+        warn(`LLM call failed for ${samplePath}: ${err.message}`);
+        return null;
+    }
+}
+
+/**
+ * Brand and acronym casing overrides applied during displayName derivation.
+ * Keys are lower-case tokens; values are the canonical user-facing rendering.
+ * Add entries here when a new acronym or brand appears in a sample folder
+ * name so the template picker doesn't show "Github" / "Mcp" / "Sdk".
+ * @type {Record<string, string>}
+ */
+const DISPLAY_NAME_TOKEN_CASING = {
+    ag: 'AG',
+    ai: 'AI',
+    api: 'API',
+    aws: 'AWS',
+    cli: 'CLI',
+    gcp: 'GCP',
+    github: 'GitHub',
+    llm: 'LLM',
+    mcp: 'MCP',
+    openai: 'OpenAI',
+    rag: 'RAG',
+    sdk: 'SDK',
+    sso: 'SSO',
+    ui: 'UI',
+};
+
+/**
+ * Derive a displayName from the template's directory name. Strips a leading
+ * numeric ordering prefix (`09-`, `12_`) so upstream reorderings don't bleed
+ * into the picker, then converts dash/underscore tokens into Title Case
+ * words and applies `DISPLAY_NAME_TOKEN_CASING` for known acronyms/brands:
+ * `09-declarative-customer-support` -> `Declarative Customer Support`,
+ * `azure-search-rag` -> `Azure Search RAG`.
+ *
+ * @param {string} samplePath
+ * @returns {string}
+ */
+function displayNameFromPath(samplePath) {
+    const dirName = samplePath.split('/').pop() || '';
+    return dirName
+        .replace(/^\d+[-_]/, '')
+        .split(/[-_]/)
+        .filter((w) => w.length > 0)
+        .map((w) => DISPLAY_NAME_TOKEN_CASING[w.toLowerCase()] ?? (w.charAt(0).toUpperCase() + w.slice(1)))
+        .join(' ');
+}
+
+/**
+ * Scan the foundry-samples repo and build the flat template list. Uses one
+ * recursive git-tree call to enumerate every `agent.yaml` under each
+ * `<language>/hosted-agents/<framework>/` prefix, regardless of intermediate
+ * directories. This supports both the canonical layout
+ * (`<framework>/<protocol>/<template>`), the flat layout
+ * (`<framework>/<template>`), and category-grouped layouts such as
+ * `bring-your-own/voicelive/hello-world-invocations-voicelive`.
+ *
+ * @param {string} commitSha
+ * @returns {Promise<Array<{language: string, framework: string, protocol: string, displayName: string, description: string, path: string, requiresModel: boolean}>>}
+ */
+async function scanTemplates(commitSha) {
+    /** @type {Array<{language: string, framework: string, protocol: string, displayName: string, description: string, path: string, requiresModel: boolean}>} */
+    const templates = [];
+
+    const { tree, truncated } = await fetchRepoTree(commitSha);
+    if (truncated) {
+        warn(`GitHub git-tree API returned truncated=true for ${commitSha}; some samples may be missing from the catalog. Consider pinning to a smaller subtree or re-running.`);
+    }
+
+    for (const language of LANGUAGES) {
+        for (const framework of FRAMEWORKS) {
+            const prefix = `samples/${language}/hosted-agents/${framework}/`;
+            const templateDirs = findTemplateDirsUnder(tree, prefix);
+
+            for (const templatePath of templateDirs) {
+                const agentInfo = await fetchAgentYaml(templatePath, commitSha);
+                if (!agentInfo) {
+                    warn(`Could not fetch or parse agent.yaml for "${templatePath}"; skipping this template.`);
+                    continue;
+                }
+
+                /** @type {'responses' | 'invocations'} */
+                const protocol = agentInfo.protocols.length > 0
+                    ? agentInfo.protocols[0]
+                    : inferProtocolFromPath(templatePath);
+
+                let requiresModel = agentInfo.hasModelEnv;
+                // Only consult agent.manifest.yaml when agent.yaml reported no
+                // model env; otherwise we already default to `true`.
+                if (!requiresModel) {
+                    const manifestInfo = await fetchAgentManifestYaml(templatePath, commitSha);
+                    if (manifestInfo?.hasModelResource) {
+                        requiresModel = true;
+                    }
+                }
+
+                templates.push({
+                    language,
+                    framework,
+                    protocol,
+                    displayName: '',
+                    description: '',
+                    path: templatePath,
+                    requiresModel,
+                });
+            }
+        }
+    }
+
+    return templates;
+}
+
+/**
+ * Build the dimensions section from discovered templates and defaults.
+ * Option order follows the insertion order of `DIMENSION_DEFAULTS[dim].options`
+ * so we have UX control (e.g. promote `copilot-sdk` ahead of
+ * `agent-framework`). Any id seen in the scanned templates but not declared in
+ * the defaults is appended at the end in alphabetical order, so a new
+ * framework added upstream does not break the build — just shows up last.
+ *
+ * @param {Array<{language: string, framework: string, protocol: string}>} templates
+ */
+function buildDimensions(templates) {
+    /** @type {Record<string, {title: string, placeholder: string, options: Array<{id: string, displayName: string}>}>} */
+    const dimensions = {};
+
+    for (const dimKey of /** @type {const} */ (['language', 'framework', 'protocol'])) {
+        const defaults = DIMENSION_DEFAULTS[dimKey];
+        const seenIds = new Set(templates.map((t) => t[dimKey]));
+        const declaredOrder = Object.keys(defaults.options);
+        const orderedIds = [
+            ...declaredOrder.filter((id) => seenIds.has(id)),
+            ...[...seenIds].filter((id) => !declaredOrder.includes(id)).sort(),
+        ];
+        const options = orderedIds.map((id) => ({
+            id,
+            displayName: defaults.options[id] || id,
+        }));
+        dimensions[dimKey] = {
+            title: defaults.title,
+            placeholder: defaults.placeholder,
+            options,
+        };
+    }
+
+    return dimensions;
+}
+
+/**
+ * Preserve existing displayName and description from the current catalog.
+ * Only non-empty existing values are kept — never overwritten.
+ * @param {Array<{displayName: string, description: string, path: string}>} templates
+ */
+function mergeExistingDisplayFields(templates) {
+    if (!existsSync(OUTPUT_PATH)) {
+        return;
+    }
+
+    try {
+        const existing = JSON.parse(readFileSync(OUTPUT_PATH, 'utf-8'));
+        /** @type {Map<string, {displayName?: string, description?: string}>} */
+        const existingByPath = new Map();
+        for (const t of existing.templates || []) {
+            if (t.path) {
+                existingByPath.set(t.path, t);
+            }
+        }
+
+        const scannedPaths = new Set(templates.map((t) => t.path));
+        for (const template of templates) {
+            const prev = existingByPath.get(template.path);
+            if (prev) {
+                if (prev.displayName) {
+                    template.displayName = prev.displayName;
+                }
+                if (prev.description) {
+                    template.description = prev.description;
+                }
+            }
+        }
+        // Surface paths that exist in the prior catalog but were not produced
+        // by this scan — upstream likely renamed or removed the sample, and any
+        // PM-edited displayName/description on it has been dropped.
+        for (const [path, prev] of existingByPath) {
+            if (scannedPaths.has(path)) {
+                continue;
+            }
+            const hadEdits = Boolean(prev.displayName || prev.description);
+            const suffix = hadEdits ? ' Previously-edited displayName/description were dropped.' : '';
+            warn(`Template "${path}" was in the previous catalog but no longer matches any scanned sample (upstream may have renamed or removed it).${suffix}`);
+        }
+    } catch (/** @type {any} */ err) {
+        warn(`Could not read existing catalog at ${OUTPUT_PATH}: ${err.message}. Existing displayName/description values were NOT preserved this run.`);
+    }
+}
+
+/**
+ * Load source-controlled per-path overrides. Returns an empty map when the
+ * file is missing or unreadable so generation never fails on it.
+ *
+ * @returns {Map<string, Record<string, unknown>>}
+ */
+function loadOverrides() {
+    /** @type {Map<string, Record<string, unknown>>} */
+    const byPath = new Map();
+    if (!existsSync(OVERRIDES_PATH)) {
+        return byPath;
+    }
+    try {
+        const raw = JSON.parse(readFileSync(OVERRIDES_PATH, 'utf-8'));
+        const entries = (raw && typeof raw === 'object' && raw.byPath) || {};
+        for (const [path, fields] of Object.entries(entries)) {
+            if (fields && typeof fields === 'object') {
+                byPath.set(path, /** @type {Record<string, unknown>} */ (fields));
+            }
+        }
+    } catch (/** @type {any} */ err) {
+        warn(`Could not read sample-overrides.json: ${err.message}`);
+    }
+    return byPath;
+}
+
+/**
+ * Shallow-merge per-path overrides onto scanned templates. Lets us correct
+ * structural fields (e.g. `framework: "copilot-sdk"` for a sample that lives
+ * under `bring-your-own/` upstream) without touching upstream or hand-editing
+ * the generated catalog. Unknown override paths are logged but never fail
+ * the build — upstream may have moved a sample.
+ *
+ * @param {Array<{path: string} & Record<string, unknown>>} templates
+ * @param {Map<string, Record<string, unknown>>} overrides
+ */
+function applyOverrides(templates, overrides) {
+    if (overrides.size === 0) {
+        return;
+    }
+    /** @type {Set<string>} */
+    const seenPaths = new Set();
+    for (const template of templates) {
+        seenPaths.add(template.path);
+        const fields = overrides.get(template.path);
+        if (fields) {
+            Object.assign(template, fields);
+        }
+    }
+    for (const path of overrides.keys()) {
+        if (!seenPaths.has(path)) {
+            warn(`Override for "${path}" did not match any scanned template; check sample-overrides.json (upstream may have moved or renamed the sample).`);
+        }
+    }
+}
+
+/**
+ * Auto-fill empty displayName and description fields.
+ *
+ * displayName is ALWAYS derived from the template's directory name when empty
+ * — the LLM is not consulted, because folder-name derivation is deterministic
+ * and PM-predictable. Existing PM-curated displayName values are preserved by
+ * the prior `mergeExistingDisplayFields` step, so this only affects newly
+ * scanned templates.
+ *
+ * description is filled by the LLM (when configured) using the sample's
+ * README as context. Without LLM credentials the description stays empty and
+ * gets surfaced as an anomaly in the step summary.
+ *
+ * @param {Array<{displayName: string, description: string, path: string}>} templates
+ * @param {string} commitSha
+ */
+async function autoFillDisplayFields(templates, commitSha) {
+    // Fill displayName first — deterministic, no API calls.
+    for (const template of templates) {
+        if (!template.displayName) {
+            template.displayName = displayNameFromPath(template.path);
+        }
+    }
+
+    const needsDescription = templates.filter((t) => !t.description);
+    if (needsDescription.length === 0) {
+        console.log('All templates already have a description.');
+    } else {
+        const hasLLM = Boolean(AZURE_OPENAI_ENDPOINT && AZURE_OPENAI_API_KEY);
+        if (hasLLM) {
+            console.log(`Generating descriptions for ${needsDescription.length} templates using LLM...`);
+            for (const template of needsDescription) {
+                const readme = await fetchReadme(template.path, commitSha);
+                if (!readme) {
+                    continue;
+                }
+                const result = await generateWithLLM(readme, template.path);
+                if (result?.description) {
+                    template.description = result.description;
+                }
+            }
+        } else {
+            console.log(`${needsDescription.length} templates need a description but no LLM is configured; leaving empty (will be flagged as anomalies).`);
+        }
+    }
+
+    // displayName always gets filled by the folder-name fallback above, so
+    // anomaly detection here is description-only.
+    for (const template of templates) {
+        if (!template.description) {
+            warn(`Template "${template.path}" is missing: description. PM should fill it before merge.`);
+        }
+    }
+}
+
+async function main() {
+    const commitSha = parseCommitShaArg();
+    console.log(`Using commit: ${commitSha}`);
+
+    console.log('Scanning templates...');
+    const templates = await scanTemplates(commitSha);
+    console.log(`Found ${templates.length} templates`);
+
+    // Step 1: Preserve existing PM-curated displayName/description values.
+    mergeExistingDisplayFields(templates);
+
+    // Step 2: Apply source-controlled per-path overrides (structural fields like
+    // `framework` that the upstream tree layout cannot express on its own).
+    applyOverrides(templates, loadOverrides());
+
+    // Step 3: Fill remaining empties — displayName from folder name (always),
+    // description from the LLM when configured.
+    await autoFillDisplayFields(templates, commitSha);
+
+    const dimensions = buildDimensions(templates);
+
+    const catalog = {
+        commitSha,
+        repo: SAMPLES_REPO_URL,
+        generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        dimensions,
+        templateSelection: TEMPLATE_SELECTION,
+        templates,
+    };
+
+    const outputDir = dirname(OUTPUT_PATH);
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(OUTPUT_PATH, JSON.stringify(catalog, null, 4) + '\n', 'utf-8');
+
+    console.log(`Wrote ${OUTPUT_PATH}`);
+
+    writeSummary(templates.length);
+}
+
+/**
+ * Append a Markdown report to `$GITHUB_STEP_SUMMARY` (when running in CI) that
+ * surfaces the warnings collected during this run. Reviewers otherwise have
+ * to scroll through raw job logs to notice anomalies like templates missing
+ * descriptions or unmatched overrides. Locally (no env var) this is a no-op.
+ *
+ * @param {number} templateCount
+ */
+function writeSummary(templateCount) {
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    if (!summaryPath) {
+        if (warnings.length > 0) {
+            console.warn(`\nCatalog generation produced ${warnings.length} warning(s) (see WARN lines above).`);
+        }
+        return;
+    }
+
+    const lines = [
+        '',
+        '## Sample Catalog Generation',
+        '',
+        `- Templates discovered: **${templateCount}**`,
+        `- Warnings emitted: **${warnings.length}**`,
+        '',
+    ];
+
+    if (warnings.length > 0) {
+        lines.push('### ⚠ Anomalies');
+        lines.push('');
+        lines.push('These were logged during generation and may need human attention before merging:');
+        lines.push('');
+        for (const message of warnings) {
+            lines.push(`- ${message}`);
+        }
+        lines.push('');
+    } else {
+        lines.push('No anomalies detected. ✅');
+        lines.push('');
+    }
+
+    try {
+        appendFileSync(summaryPath, lines.join('\n'), 'utf-8');
+    } catch (/** @type {any} */ err) {
+        console.warn(`Could not append to GITHUB_STEP_SUMMARY: ${err.message}`);
+    }
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -40,6 +40,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -99,7 +106,7 @@ jobs:
         id: labels
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -137,12 +144,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          # Uses the built-in GITHUB_TOKEN; PRs opened with this token will
-          # NOT trigger downstream workflows (GitHub's anti-recursion rule).
-          # That is fine for this repo today — there are no PR checks that
-          # need to run on the auto-PR. If that changes, switch to a GitHub
-          # App token (actions/create-github-app-token@v1).
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: ${{ steps.branch.outputs.name }}
           base: ${{ github.ref_name }}
           delete-branch: true

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -7,6 +7,13 @@ on:
         description: "Commit SHA from microsoft-foundry/foundry-samples to pin to"
         required: true
         type: string
+  # TEMP: bootstrap-only — lets us smoke-test the pipeline from the feature
+  # branch before it lands on the default branch (workflow_dispatch requires
+  # the file to exist on the default branch first). Revert this whole block
+  # together with the DEFAULT_COMMIT_SHA env below before merging.
+  push:
+    branches:
+      - yimin/sync-catalog-bootstrap
 
 permissions:
   contents: write
@@ -45,7 +52,10 @@ jobs:
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
-        run: node .github/scripts/generate_sample_catalog.mjs "${{ inputs.commit_sha }}"
+          # TEMP: bootstrap-only fallback for push-triggered smoke test. Revert
+          # together with the `push` trigger block above before merging.
+          DEFAULT_COMMIT_SHA: '19b441d474ec963c61a509692fdd81d5fb707d71'
+        run: node .github/scripts/generate_sample_catalog.mjs "${{ inputs.commit_sha || env.DEFAULT_COMMIT_SHA }}"
 
       - name: Detect catalog changes
         id: diff

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -8,9 +8,11 @@ on:
         required: true
         type: string
 
+# Least-privilege for the default GITHUB_TOKEN: only what `actions/checkout`
+# needs. All writes (push branch + create PR) are performed via the GitHub
+# App token generated below, not GITHUB_TOKEN.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # A single in-flight sync at a time — a re-trigger cancels any earlier run
 # rather than racing it for the same PR branch.

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -7,13 +7,6 @@ on:
         description: "Commit SHA from microsoft-foundry/foundry-samples to pin to"
         required: true
         type: string
-  # TEMP: bootstrap-only — lets us smoke-test the pipeline from the feature
-  # branch before it lands on the default branch (workflow_dispatch requires
-  # the file to exist on the default branch first). Revert this whole block
-  # together with the DEFAULT_COMMIT_SHA env below before merging.
-  push:
-    branches:
-      - yimin/sync-catalog-bootstrap
 
 permissions:
   contents: write
@@ -59,10 +52,7 @@ jobs:
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
-          # TEMP: bootstrap-only fallback for push-triggered smoke test. Revert
-          # together with the `push` trigger block above before merging.
-          DEFAULT_COMMIT_SHA: '19b441d474ec963c61a509692fdd81d5fb707d71'
-        run: node .github/scripts/generate_sample_catalog.mjs "${{ inputs.commit_sha || env.DEFAULT_COMMIT_SHA }}"
+        run: node .github/scripts/generate_sample_catalog.mjs "${{ inputs.commit_sha }}"
 
       - name: Detect catalog changes
         id: diff

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -33,13 +33,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -96,7 +89,7 @@ jobs:
         id: labels
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -134,7 +127,12 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          # Uses the built-in GITHUB_TOKEN; PRs opened with this token will
+          # NOT trigger downstream workflows (GitHub's anti-recursion rule).
+          # That is fine for this repo today — there are no PR checks that
+          # need to run on the auto-PR. If that changes, switch to a GitHub
+          # App token (actions/create-github-app-token@v1).
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ steps.branch.outputs.name }}
           base: ${{ github.ref_name }}
           delete-branch: true

--- a/.github/workflows/sync-sample-catalog.yml
+++ b/.github/workflows/sync-sample-catalog.yml
@@ -1,0 +1,186 @@
+name: Sync Sample Catalog
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "Commit SHA from microsoft-foundry/foundry-samples to pin to"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# A single in-flight sync at a time — a re-trigger cancels any earlier run
+# rather than racing it for the same PR branch.
+concurrency:
+  group: sync-sample-catalog-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      PR_LABEL_CANDIDATES: |
+        automated-pr
+        area:samples
+        area:hosted-agent
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate sample catalog
+        env:
+          REPO_ROOT: ${{ github.workspace }}
+          GITHUB_TOKEN: ${{ github.token }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
+        run: node .github/scripts/generate_sample_catalog.mjs "${{ inputs.commit_sha }}"
+
+      - name: Detect catalog changes
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          catalog_file="samples/hosted-agent/sample-catalog.json"
+
+          if [[ ! -f "$catalog_file" ]]; then
+            echo "Catalog file not generated."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Stage the file so git diff detects both new and modified files
+          git add "$catalog_file"
+
+          if git diff --cached --quiet -- "$catalog_file"; then
+            echo "No changes to sample catalog."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Catalog has changes:"
+          git diff --cached --stat -- "$catalog_file"
+
+          {
+            echo "## Sample Catalog Sync"
+            echo
+            echo "The sample catalog was regenerated from \`microsoft-foundry/foundry-samples\`."
+            echo
+            echo "### Changed files"
+            echo "- \`$catalog_file\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve pull request labels
+        if: steps.diff.outputs.has_changes == 'true'
+        id: labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          existing_labels=$(gh api --paginate repos/${{ github.repository }}/labels --jq '.[].name')
+          matched_labels=""
+
+          while IFS= read -r candidate; do
+            if [[ -z "$candidate" ]]; then
+              continue
+            fi
+
+            if grep -Fqx "$candidate" <<< "$existing_labels"; then
+              matched_labels+="$candidate"
+              matched_labels+=$'\n'
+            fi
+          done <<< "$PR_LABEL_CANDIDATES"
+
+          {
+            echo "labels<<EOF"
+            printf '%s' "$matched_labels"
+            echo
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate PR branch name
+        if: steps.diff.outputs.has_changes == 'true'
+        id: branch
+        shell: bash
+        run: |
+          date_suffix=$(date -u +%Y%m%d)
+          echo "name=ci/sync-sample-catalog-${{ github.ref_name }}-${date_suffix}" >> "$GITHUB_OUTPUT"
+
+      - name: Create draft pull request
+        if: steps.diff.outputs.has_changes == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ steps.branch.outputs.name }}
+          base: ${{ github.ref_name }}
+          delete-branch: true
+          draft: always-true
+          commit-message: |
+            ci: sync sample catalog from foundry-samples (${{ github.ref_name }})
+          title: "ci: sync sample catalog from foundry-samples (${{ github.ref_name }})"
+          body: |
+            ## Summary
+            This automated draft PR updates `samples/hosted-agent/sample-catalog.json` by scanning
+            the `microsoft-foundry/foundry-samples` repository for hosted-agent sample templates.
+
+            ## What changed
+            - New templates added or removed based on the upstream repo structure.
+            - `commitSha` pinned to the upstream commit supplied via the `commit_sha` workflow input.
+            - `requiresModel` and `protocol` values re-derived from each sample's `agent.yaml`.
+            - `displayName` derived from each template's folder name; `description` LLM-generated when empty.
+            - PM-edited `displayName` and `description` values are preserved from the previous catalog.
+
+            ## Reviewer Checks
+            - Confirm new templates have correct `language`, `framework`, and `protocol` values.
+            - Review the auto-generated `description` for any new templates.
+            - Confirm no PM-edited display fields were accidentally lost.
+          labels: ${{ steps.labels.outputs.labels }}
+          add-paths: |
+            samples/hosted-agent/sample-catalog.json
+
+      - name: Report PR result
+        if: steps.diff.outputs.has_changes == 'true'
+        shell: bash
+        env:
+          PR_OPERATION: ${{ steps.cpr.outputs.pull-request-operation }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "PR operation: $PR_OPERATION"
+          echo "PR URL: $PR_URL"
+
+          {
+            echo
+            echo "## Pull Request"
+            echo
+            if [[ -n "$PR_URL" ]]; then
+              echo "- Operation: \`$PR_OPERATION\`"
+              echo "- PR: [#${PR_NUMBER:-?}]($PR_URL)"
+            else
+              echo "- No pull request was created or updated (peter-evans/create-pull-request returned no URL)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -1,0 +1,527 @@
+{
+    "commitSha": "19b441d474ec963c61a509692fdd81d5fb707d71",
+    "repo": "https://github.com/microsoft-foundry/foundry-samples/",
+    "generatedAt": "2026-05-27T06:40:47Z",
+    "dimensions": {
+        "language": {
+            "title": "Select a Language",
+            "placeholder": "Choose the language for your agent",
+            "options": [
+                {
+                    "id": "python",
+                    "displayName": "Python"
+                },
+                {
+                    "id": "csharp",
+                    "displayName": "C# (.NET)"
+                }
+            ]
+        },
+        "framework": {
+            "title": "Select a Framework",
+            "placeholder": "Choose the framework for your agent",
+            "options": [
+                {
+                    "id": "copilot-sdk",
+                    "displayName": "Copilot SDK"
+                },
+                {
+                    "id": "agent-framework",
+                    "displayName": "Agent Framework"
+                },
+                {
+                    "id": "bring-your-own",
+                    "displayName": "Bring Your Own"
+                }
+            ]
+        },
+        "protocol": {
+            "title": "Select a Protocol",
+            "placeholder": "Choose the protocol for your agent",
+            "options": [
+                {
+                    "id": "responses",
+                    "displayName": "Responses API"
+                },
+                {
+                    "id": "invocations",
+                    "displayName": "Invocations API"
+                }
+            ]
+        }
+    },
+    "templateSelection": {
+        "title": "Select a Template",
+        "placeholder": "Choose a template for your agent"
+    },
+    "templates": [
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "invocations",
+            "displayName": "Basic",
+            "description": "Agent with in-memory session management for multi-turn conversations.",
+            "path": "samples/python/hosted-agents/agent-framework/invocations/01-basic",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Basic",
+            "description": "Agent that supports multi-turn conversations with response tracking.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/01-basic",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Tools",
+            "description": "Agent with custom tools like weather lookup callable during conversation.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/02-tools",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "MCP",
+            "description": "Agent that dynamically discovers and invokes tools from a remote GitHub Copilot MCP server.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/03-mcp",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Foundry Toolbox",
+            "description": "Agent that discovers and invokes centrally managed tools from a Foundry Toolbox.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Workflows",
+            "description": "Processes requests through slogan writing, legal review, and formatting agents in sequence.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/05-workflows",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Files",
+            "description": "Agent that lists, reads, and interprets files using shell and code tools.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/06-files",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Skills",
+            "description": "Agent that discovers and runs local file-based skills like generating PDF travel guides.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/07-skills",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Observability",
+            "description": "Agent with built-in observability and telemetry for diagnostics and monitoring.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/08-observability",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Declarative Customer Support",
+            "description": "Customer support triage agent that routes requests to specialized agents based on conversation history.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/09-declarative-customer-support",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Downstream Azure",
+            "description": "Agent performs data operations on Blob Storage and Service Bus using its own identity.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/10-downstream-azure",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Azure Search RAG",
+            "description": "Answers questions using product documentation and cites sources from a search index.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/11-azure-search-rag",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Foundry Skills",
+            "description": "Agent that loads behavioral guidelines from Foundry Skills at startup for dynamic updates.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/12-foundry-skills",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Foundry Memory",
+            "description": "Agent that remembers user facts across sessions using persistent semantic memory.",
+            "path": "samples/python/hosted-agents/agent-framework/responses/13-foundry-memory",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "AG UI",
+            "description": "Agent that streams AG-UI lifecycle events in response to user input.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/ag-ui",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Claude Agent SDK",
+            "description": "Agent that streams responses from a Claude model for plain text input.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk",
+            "requiresModel": false
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Event Grid Trigger",
+            "description": "Agent triggered by Azure Storage events that summarizes uploaded blobs and saves results separately.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "copilot-sdk",
+            "protocol": "invocations",
+            "displayName": "GitHub Copilot",
+            "description": "Agent streams Copilot session events with support for multi-turn conversations.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/github-copilot",
+            "requiresModel": false
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Hello World",
+            "description": "Hosted agent that streams a model's reply as a server-sent event.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/hello-world",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Human In The Loop",
+            "description": "Agent that generates proposals and waits for human approval before proceeding.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Langgraph Chat",
+            "description": "Conversational agent with session history and built-in time and calculator tools.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Notetaking Agent",
+            "description": "Agent that saves and retrieves notes with per-session isolation and streaming responses.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Toolbox",
+            "description": "Agent connects to a toolbox server and enables tool discovery and invocation during chat.",
+            "path": "samples/python/hosted-agents/bring-your-own/invocations/toolbox",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Background Agent",
+            "description": "Handles long-running research analysis requests with background processing and streaming updates.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/background-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Bring Your Own Toolbox",
+            "description": "Agent connects to a remote toolbox and enables tool invocation during conversations.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Env Vars Agent",
+            "description": "Agent that reveals environment variable values with safety policies based on their type.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/env-vars-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Hello World",
+            "description": "Hosted agent that returns a hello world message from a Foundry model using a custom backend.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/hello-world",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Langgraph Chat",
+            "description": "Conversational agent with built-in calculator and time tools, streaming responses.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-chat",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Langgraph Toolbox",
+            "description": "Agent that dynamically loads tools from a remote toolbox and handles incoming requests.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Langgraph Toolbox User Identity",
+            "description": "Agent that accesses mail, calendar, and GitHub tools for user-identity scenarios.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Notetaking Agent",
+            "description": "Agent that saves and retrieves notes with per-session isolation and streaming responses.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/notetaking-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "OpenAI Agents SDK",
+            "description": "Minimal agent that streams text responses from a Foundry model.",
+            "path": "samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk",
+            "requiresModel": true
+        },
+        {
+            "language": "python",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Hello World Invocations Voicelive",
+            "description": "Minimal hosted agent for real-time voice interactions with audio transcription streaming.",
+            "path": "samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Agent Skills",
+            "description": "Agent that loads behavioral guidelines from Foundry Skills at startup for dynamic updates.",
+            "path": "samples/csharp/hosted-agents/agent-framework/agent-skills",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Azure Search RAG",
+            "description": "Support agent answers questions using a keyword-indexed knowledge base for grounding.",
+            "path": "samples/csharp/hosted-agents/agent-framework/azure-search-rag",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "File Tools",
+            "description": "Agent answers questions using bundled and user-uploaded files as knowledge sources.",
+            "path": "samples/csharp/hosted-agents/agent-framework/file-tools",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Foundry Memory RAG",
+            "description": "Personal coach agent that remembers user preferences and goals across sessions.",
+            "path": "samples/csharp/hosted-agents/agent-framework/foundry-memory-rag",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Foundry Toolbox Server Side",
+            "description": "Agent that uses tools from a Foundry Toolbox, invoked server-side by the platform.",
+            "path": "samples/csharp/hosted-agents/agent-framework/foundry-toolbox-server-side",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Hello World",
+            "description": "Minimal hosted agent that responds to user questions and supports multi-turn conversation.",
+            "path": "samples/csharp/hosted-agents/agent-framework/hello-world",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "invocations",
+            "displayName": "Invocations Echo Agent",
+            "description": "Echoes back input messages with a simple prefix for testing agent hosting.",
+            "path": "samples/csharp/hosted-agents/agent-framework/invocations-echo-agent",
+            "requiresModel": false
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Local Tools",
+            "description": "Hotel search assistant that uses local function tools for queries.",
+            "path": "samples/csharp/hosted-agents/agent-framework/local-tools",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "MCP Tools",
+            "description": "Agent answers questions by searching documentation using integrated tool providers.",
+            "path": "samples/csharp/hosted-agents/agent-framework/mcp-tools",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Simple Agent",
+            "description": "General-purpose AI assistant that replies to user input with model-generated responses.",
+            "path": "samples/csharp/hosted-agents/agent-framework/simple-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Text Search RAG",
+            "description": "Agent answers support questions using retrieved passages from external documents.",
+            "path": "samples/csharp/hosted-agents/agent-framework/text-search-rag",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "agent-framework",
+            "protocol": "responses",
+            "displayName": "Workflows",
+            "description": "Workflow chains three translation agents to show intermediate language outputs.",
+            "path": "samples/csharp/hosted-agents/agent-framework/workflows",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "HelloWorld",
+            "description": "Hosted agent that returns a streaming hello world response from a Foundry model.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/HelloWorld",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Human In The Loop",
+            "description": "Agent that generates proposals and waits for human approval before proceeding.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/human-in-the-loop",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "invocations",
+            "displayName": "Notetaking Agent",
+            "description": "Agent that saves and retrieves session-persistent notes with real-time streaming responses.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/invocations/notetaking-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "HelloWorld",
+            "description": "Minimal hosted agent that returns a greeting from a Foundry model using the Responses API.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/responses/HelloWorld",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Background Agent",
+            "description": "Handles research analysis requests asynchronously with background processing and streaming updates.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/responses/background-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Env Vars Agent",
+            "description": "Agent retrieves environment variable values with safety policies based on their type.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/responses/env-vars-agent",
+            "requiresModel": true
+        },
+        {
+            "language": "csharp",
+            "framework": "bring-your-own",
+            "protocol": "responses",
+            "displayName": "Notetaking Agent",
+            "description": "Agent that saves and retrieves session-persistent notes for each user.",
+            "path": "samples/csharp/hosted-agents/bring-your-own/responses/notetaking-agent",
+            "requiresModel": true
+        }
+    ]
+}

--- a/samples/hosted-agent/sample-overrides.json
+++ b/samples/hosted-agent/sample-overrides.json
@@ -1,0 +1,8 @@
+{
+    "byPath": {
+        "samples/python/hosted-agents/bring-your-own/invocations/github-copilot": {
+            "framework": "copilot-sdk",
+            "requiresModel": false
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Bootstrap the sample-catalog sync pipeline in this repo, mirroring what was
just landed in [microsoft-foundry-for-vscode](https://github.com/microsoft/microsoft-foundry-for-vscode)
(PRs [#643](https://github.com/microsoft/microsoft-foundry-for-vscode/pull/643)
and [#646](https://github.com/microsoft/microsoft-foundry-for-vscode/pull/646)).

## What this adds

| File | Purpose |
|------|---------|
| `.github/workflows/sync-sample-catalog.yml` | `workflow_dispatch` job that runs the generator, opens a draft PR with the refreshed catalog, and labels it. |
| `.github/scripts/generate_sample_catalog.mjs` | Walks the upstream `microsoft-foundry/foundry-samples` repo, extracts metadata from `agent.yaml` / `agent.manifest.yaml`, merges overrides, and writes `samples/hosted-agent/sample-catalog.json`. |
| `samples/hosted-agent/sample-overrides.json` | PM-managed per-path framework/requiresModel/displayName/description overrides. |
| `samples/hosted-agent/sample-catalog.json` | Initially generated catalog (added by the workflow's first run via the auto-PR it created against this branch). |

## How the workflow authenticates

PR creation goes through a dedicated GitHub App (see `Generate GitHub App
token` step). This matches the source workflow in
`microsoft-foundry-for-vscode` and is required because the `microsoft` org
blocks the built-in `GITHUB_TOKEN` from creating or approving pull requests.

The default `GITHUB_TOKEN` is scoped to `contents: read` (only what
`actions/checkout` needs); all write operations use the App token.

## Required secrets (must be configured before triggering the workflow)

| Secret | Purpose |
|--------|---------|
| `SYNC_APP_ID` | App ID of the GitHub App used to author the auto-PRs. |
| `SYNC_APP_PRIVATE_KEY` | Private key (PEM) for that App. |
| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI endpoint used to generate `description` fields when an entry has none. |
| `AZURE_OPENAI_API_KEY` | Azure OpenAI key. |
| `AZURE_OPENAI_DEPLOYMENT` | Deployment name (currently `gpt-4o-mini`). |

The App must be installed on this repo with `Contents: write` and
`Pull requests: write` permissions.

## Reviewer checks

- [ ] Workflow has only the `workflow_dispatch` trigger (won't auto-run on push/PR).
- [ ] Default `GITHUB_TOKEN` is scoped to `contents: read`; writes go via the App token.
- [ ] Secrets list matches what the workflow actually references.
