### PR TITLE
ci(catalog): blacklist invocations_ws sample paths

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -76,6 +76,11 @@ const TEMPLATE_SELECTION = {
 // Path segments must be alphanumeric, hyphens, underscores, or dots
 const SAFE_PATH_SEGMENT = /^[a-zA-Z0-9._-]+$/;
 
+// Path segments that should never surface as catalog templates, even when
+// they contain a valid `agent.yaml`. Use this to drop upstream folders we
+// don't want in the picker yet (e.g. `invocations_ws` LiveKit samples).
+const BLOCKED_PATH_SEGMENTS = new Set(['invocations_ws']);
+
 /**
  * Collected anomaly messages surfaced in CI step summary so reviewers do not
  * silently merge a catalog with missing/derived data. Always populated, even
@@ -199,7 +204,14 @@ function findTemplateDirsUnder(tree, prefix) {
             if (!rel) {
                 return false;
             }
-            return rel.split('/').every((seg) => isSafePathSegment(seg));
+            const segments = rel.split('/');
+            if (!segments.every((seg) => isSafePathSegment(seg))) {
+                return false;
+            }
+            // Drop templates that live under a blocked segment (e.g.
+            // `invocations_ws`) so upstream additions don't auto-leak into
+            // the catalog before we explicitly opt them in.
+            return !segments.some((seg) => BLOCKED_PATH_SEGMENTS.has(seg));
         })
         // Lexicographic sort serves two purposes: (1) a parent path always
         // sorts before its descendants, so the `startsWith` check below


### PR DESCRIPTION
## Why

Upstream `microsoft-foundry/foundry-samples` recently added
`samples/python/hosted-agents/bring-your-own/invocations_ws/{hello-world,livekit-server}`
(LiveKit voice prototypes). The catalog generator's loose path scan picks
them up as `invocations` templates, but they shouldn't appear in the
picker yet - they're not the standard invocations protocol.

When the workflow is dispatched against `template/stable` (the branch we
actually run from today), the older script is still picking these up — even
though the equivalent fix #410 already landed on `main`.

## What

Add a small `BLOCKED_PATH_SEGMENTS` deny-list to the catalog generator and
drop any template whose path contains a blocked segment.

`js
const BLOCKED_PATH_SEGMENTS = new Set(['invocations_ws']);
`

Cherry-picked from #410 verbatim (same diff, +13 / -1).

Minimal-surface change vs. a whitelist rewrite:
- existing csharp flat layouts stay surfaced,
- the `voicelive` sample stays surfaced,
- only `invocations_ws` is filtered out.

## Branch model

PR #408 brought the workflow files to `main` purely so the
`workflow_dispatch` `Run workflow` button renders. The actual runs are
dispatched against `template/*` branches, so the source of truth for the
generator / catalog data lives on the template branches. From now on,
catalog-related changes should land on a template branch and propagate via
the normal sync workflows; `main` stays as a dispatch-enabler shim.

## Follow-ups

- Forward this fix to `template/pre-release` and `template/stable` so
  the deny-list is in effect wherever the workflow is dispatched.

## Smoke test

`node -c .github/scripts/generate_sample_catalog.mjs` parses clean.
Functional verification happens on the next `workflow_dispatch` run from
`template/dev`.