### PR TITLE
ci(catalog): add LangGraph framework

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -35,7 +35,7 @@ const OVERRIDES_PATH = join(REPO_ROOT, 'samples', 'hosted-agent', 'sample-overri
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN || '';
 
 const LANGUAGES = ['python', 'csharp'];
-const FRAMEWORKS = ['agent-framework', 'bring-your-own'];
+const FRAMEWORKS = ['agent-framework', 'bring-your-own', 'langgraph'];
 
 /** @type {Record<string, {title: string, placeholder: string, options: Record<string, string>}>} */
 const DIMENSION_DEFAULTS = {
@@ -56,6 +56,7 @@ const DIMENSION_DEFAULTS = {
             'copilot-sdk': 'Copilot SDK',
             'agent-framework': 'Agent Framework',
             'bring-your-own': 'Bring Your Own',
+            'langgraph': 'LangGraph',
         },
     },
     protocol: {


### PR DESCRIPTION
## Why

Upstream `microsoft-foundry/foundry-samples` added a new framework subtree
under `samples/python/hosted-agents/langgraph/` (7 templates today across
`invocations/` and `responses/`). The catalog generator hard-codes the
framework whitelist, so the entire langgraph subtree is being silently
skipped — none of those templates show up in the picker.

## What

Two-line addition (+2 / -1) to `.github/scripts/generate_sample_catalog.mjs`:

1. Append `'langgraph'` to `FRAMEWORKS` so `scanTemplates` picks up
   the new `samples/<lang>/hosted-agents/langgraph/` prefix.
2. Append `'langgraph': 'LangGraph'` (CamelCase per upstream branding) to
   `DIMENSION_DEFAULTS.framework.options` as the **last** option, keeping
   the existing `copilot-sdk` → `agent-framework` → `bring-your-own`
   order intact.

## Catalog impact

No catalog regeneration in this PR. The next `Sync Sample Catalog`
workflow run dispatched from `template/dev` will produce a follow-up PR
that:

- adds a `langgraph` option to the `framework` dimension,
- adds the 7 `samples/python/hosted-agents/langgraph/**` templates to
  `templates[]`.

## Smoke test

`node -c .github/scripts/generate_sample_catalog.mjs` parses clean.