### PR TITLE
ci: require Yimin-Jin or huimiu approval on template/pre-release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for template/pre-release.
+#
+# GitHub uses this file (combined with the branch's
+# `require_code_owner_reviews` protection rule) to enforce that every PR
+# targeting this branch is approved by at least one listed owner. The line
+# below applies repo-wide; either owner can satisfy the requirement.
+*       @Yimin-Jin @huimiu


### PR DESCRIPTION
## Why

We want every PR targeting `template/pre-release` to be gated on at least
one approval from a domain owner (Yimin-Jin or huimiu).

## What

Add `.github/CODEOWNERS` with a single repo-wide rule:

```
*       @Yimin-Jin @huimiu
```

Either owner can satisfy the requirement.

## Follow-ups (admin)

After this merges, enable `require_code_owner_reviews: true` on this
branch's protection rule so the requirement is actually enforced. (Parallel
PR for `template/stable` is #419.)