### PR TITLE
docs: sync latest changelog entries

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,6 +1,184 @@
-# What's New in AI Toolkit for VS Code Preview
+# What's New in Foundry Toolkit for VS Code
 
-AI Toolkit is an extension pack that includes Microsoft Foundry. For Microsoft Foundry changes, see the [Microsoft Foundry Changelog](https://marketplace.visualstudio.com/items/TeamsDevApp.vscode-ai-foundry/changelog).
+## Version 1.4.1 - 1 June, 2026
+
+This incremental release adds model export, optimization, and quantization through WinML CLI, introduces resource usage interval updates for model profiling, aligns Windows ML with Windows App SDK 2.0, and polishes the Hosted Agent creation and deployment flow.
+
+### Added
+
+- **Model Conversion**
+  - Support export, optimize, quantize model via [WinML CLI](https://github.com/microsoft/winml-cli).
+  - Add new Olive recipes for SAM 2.1, SAM and Stable Diffusion 2.1
+- **Model Profiling**
+  - Support OP level data for Intel (OpenVINO) EP
+  - Support updating interval for resource usage collection
+
+### Changed
+
+- **Hosted Agent Creation**
+  - Auto-select the subscription when only one is available (or the most recently used), and refresh the subscription and project fields after a new project is created.
+  - Disable the second tab until the required selection on the first tab is complete.
+  - Align the search bar borders with the card borders in the selection panel.
+  - Polished title and description font sizes, top and side padding, label-to-input spacing, and dropdown widths to align with the rest of the create flow.
+- **Hosted Agent Deploy**
+  - Setting dropdowns default to the current value with a `(Current)` suffix for quick recognition.
+- **Model Conversion**
+  - Update Windows ML to align with [Windows App SDK 2.0](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/release-notes/windows-app-sdk-2-0?pivots=stable)
+
+### Fixed
+
+- **Hosted Agent Deploy**: Restored the **Run agent** button on the deploy page (previously only **View logs** was shown, making the page look like an error state).
+
+## Version 1.4.0 - 28 May, 2026
+
+This release marks a major milestone: the **[Foundry Toolkit](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) (previously AI Toolkit) and [Microsoft Foundry extension](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.vscode-ai-foundry) are now consolidated into a single Foundry Toolkit extension**. It also brings **Hosted Agent evaluation and tracing to GA**, two new **Hosted Agent deployment options** (ZIP code deploy and Bring-Your-Own-Image ACR), a **refreshed Hosted Agent scaffolding UI**, an expanded **Toolbox** with native **WorkIQ** and **Fabric IQ (OneLake)** integrations, a redesigned **Tools Catalog**, a refreshed **Prompt Builder**, and continuous evaluation settings for production agents.
+
+### Added
+
+- **Observability**
+  - **Hosted Agent Tracing**: Inspect end-to-end traces of Hosted Agent invocations from VS Code for debugging and observability.
+  - **Continuous Evaluation Settings**: New page to configure ongoing evaluation for deployed Hosted Agents.
+  - **Evaluations Node**: One-click access to evaluation runs and results from the Foundry project tree.
+- **Hosted Agent**
+  - **Hosted Agent ZIP Code Deploy**: Deploy your agent source as a ZIP package directly to ADC.
+  - **Hosted Agent Bring-Your-Own-Image (BYOI)**: Deploy from a pre-built container image in your own Azure Container Registry.
+- **Agent Tools and Toolboxes**
+  - **WorkIQ as a Built-in Tool**: Native WorkIQ tool experience in the Toolbox — first-class integration powered by A2A connections, no MCP fallback required. End-to-end toolbox creation with WorkIQ works out of the box.
+  - **Fabric IQ (OneLake Catalog) Integration**: Connect to Microsoft Fabric OneLake catalogs from the Toolbox.
+  - **Toolbox Search Toggle**: Faster discovery across the Tool Catalog.
+  - **Agent Tool Multi-Select**: Wire multiple tools into an agent in a single action.
+
+### Changed
+
+
+- **Hosted Agent**
+  - **Hosted Agent Scaffolding**: Refreshed UI and workflow for clearer project setup.
+  - **Dropped ACA Data-Plane Support**: Hosted Agents now target ADC exclusively.
+- **Agent Tools and Toolboxes**
+  - **Tools Catalog Redesign**: Improved layout, filtering, and tool metadata.
+  - **"Vector Store" Renamed to "Knowledge Index"**: Terminology aligned with Microsoft Foundry.
+- **Extension and UX**
+  - **Single Consolidated Extension**: AI Toolkit and Foundry extensions now ship as one VSIX, eliminating the need to install both.
+  - **Renamed AI Toolkit to Foundry Toolkit**: Updated across UI, commands, and documentation.
+  - **Prompt Builder "Improve an Instruction"**: Dialog redesigned for faster iteration.
+  - **Agent Inspector Header**: Styling aligned with the rest of the extension.
+
+### Fixed
+
+- Polished Remote Agent Playground UI alignment.
+- Fixed MCP toolbox tool icons not rendering correctly.
+- Improved ZIP deploy service error surfacing for clearer failure diagnostics.
+- Fixed regressions in the Hosted Agent deployment flow.
+- Fixed assorted UI regressions across Agent Builder and Playground.
+
+## Version 1.2.1 - 18 May, 2026
+
+This incremental release polishes the Tool Catalog UI, features **GPT-Image-2** in the Popular Models section of the Model Catalog, and fine-tunes default sidebar visibility for easier feature discovery.
+
+### Added
+
+- **GPT-Image-2 in Model Catalog**: GPT-Image-2 is now featured in the Popular Models section, alongside GPT-5.5, Claude Opus 4.7, and Phi-4.
+
+### Changed
+
+- **Tool Catalog**: New tools catalog design with refreshed layout and styling, refined toolbox editor and tool card UI, and clearer label wording across the Tools UI.
+- **Foundry Model Catalog**: Updated the Foundry collapsed-view ranking to surface the latest models — GPT-5.4, Claude Opus 4.6, Grok 4.3, DeepSeek-V4-Flash, Kimi K2.6 (Fireworks), and MiniMax M2.5 (Fireworks). The popular models grid is now responsive for four cards, with breakpoints aligned to card description visibility.
+- **Sidebar Defaults**: The **Discover** category is now expanded by default and the **Help and Feedback** view is collapsed by default for a cleaner first-run experience.
+
+## Version 1.2.0 - 6 May, 2026
+
+This release brings **Hosted Agent (public preview)** to Foundry Toolkit, upgraded **Agent Inspector**, and rounds out **Toolbox** management.
+
+### Added
+
+- **Hosted Agent (Public Preview)**: Build, deploy, and inspect Microsoft Foundry hosted agents from VS Code, powered by the new agent framework hosting package.
+- **Toolbox in Tool Catalog**: Create and manage toolboxes from the UI using the Azure AI Project SDK, with synced sample code.
+- **Test Tool — Approval & Consent**: Inspector test tool now supports approval and consent flows.
+
+### Changed
+
+- **Agent Inspector**: Reworked layout with toolbox support, refreshed Invocations view, and a switch to diagnostic side-stream for improved event delivery.
+- **Model Catalog**: Refreshed header and filter UI, enriched Foundry cards with descriptions and feature tags, and added fuzzy search.
+- **Modular Skills**: Copilot instructions converted into modular skills with progressive loading; renamed to `vscode-microsoft-foundry`.
+- **MCP**: Tokens now refresh automatically.
+
+### Fixed
+
+- Fixed oversized layouts on the Foundry Agent Builder and Create Toolbox pages.
+- Fixed prompt editor styling to match VS Code dropdowns and inputs across light, dark, and high-contrast themes.
+- Polished Model Catalog button styling, hover states, deploy icons, and tag alignment.
+- Fixed agent prompt textboxes disappearing in light and high-contrast modes ([vscode-ai-toolkit#366](https://github.com/microsoft/vscode-ai-toolkit/issues/366)).
+- Fixed playground prompt being lost when resizing the workflow / playground divider.
+- Fixed custom agent / skill generation renaming env vars and breaking Foundry deployments.
+- Improved inference agent reconnect latency and Inspector invocations stream performance.
+- Fixed the **Create New MCP Server** button label and page title.
+- Fixed model icon resolution for Qwen, DeepSeek, Mistral, GLM, and MiniMax.
+- Refreshed the **Experiment with AI Models** walkthrough images for dark and light themes.
+
+
+## Version 1.0.0 - 16 April, 2026
+
+This release marks a significant milestone as AI Toolkit becomes generally available. With this release, we are also renaming AI Toolkit to **Microsoft Foundry Toolkit for VS Code** to better reflect the deep integration and seamless experience it provides with Microsoft Foundry.
+
+All existing features remain intact with better experience and performance. In addition, we have added nine models from [Fireworks AI hosted on Microsoft Foundry](https://azure.microsoft.com/en-us/blog/introducing-fireworks-ai-on-microsoft-foundry-bringing-high-performance-low-latency-open-model-inference-to-azure/), bringing you access to models like Kimi K2.5, MiniMax M2.5, and more.
+
+Read more about our announcement [here](https://aka.ms/mftk-ga-blog).
+
+## Version 0.34.0 - 26 March, 2026
+
+This release introduces LangGraph support in Agent Inspector, a new Recent Agents section for quick navigation, a refreshed Agent Builder UI, and a broad set of improvements across MCP tooling, model compatibility, and the walkthrough experience.
+
+### Added
+
+- **LangGraph Support in Agent Inspector**: Agent Inspector now supports LangGraph agents. Visualize your LangGraph multi-agent workflows in real time and navigate directly to source code by double-clicking workflow nodes.
+
+- **Recent Agents in My Resources**: A new **Recent Agents** section in the sidebar provides quick access to recently opened agents, reducing navigation time.
+
+### Changed
+
+- **Agent Builder UI**: Restyled to align with VS Code native components — buttons, form fields, and typography now match the VS Code design language for a more cohesive experience. The **Create Agent** panel is also responsive.
+
+- **Model Picker**: Foundry models are now ranked above GitHub models in the model dropdown, making the recommended option easier to find.
+
+- **Agent Switcher**: Agents in the switcher now indicate whether they are **Local** or **Foundry** agents, reducing ambiguity when working across multiple agents.
+
+- **MCP Tool Catalog**:
+  - You can now **delete MCP servers** directly from the Tool Catalog.
+  - The "Add tool" dialog now correctly defaults to local configuration when adding a local MCP server.
+  - Tooltips and improved wording clarify where agents and tools are saved (local vs. Foundry).
+
+- **Walkthrough**: Refreshed with an agent-focused design and updated steps. Walkthrough images now support both VS Code **dark and light themes**.
+
+- **"Improve" in Agent Builder**: Now falls back gracefully when a model doesn't support the optimized API, instead of silently failing or showing an error.
+
+- **API Auto-Detection**: AI Toolkit now automatically detects whether a model requires the Responses API or Chat Completions API and switches transparently — no manual configuration needed.
+
+- **Model Catalog**: Popular models updated to the latest versions — GPT-5.4 and Claude Opus 4.6 are now featured.
+
+### Fixed
+
+- Fixed MCP name conflict error ("connection with this name already exists") after deleting and re-adding an MCP server.
+- Fixed Agent Builder model picker rendering issues in some configurations.
+- Fixed the **Improve** button not working for certain Foundry models.
+- Fixed local MCP "Add tools" section incorrectly showing Foundry tools.
+- Fixed loading overlay not fully covering the Agent Builder UI during model operations.
+- Fixed LangGraph agents encountering errors when agentdev endpoints are unavailable.
+- Fixed conversation continuity with the standard Responses API.
+
+
+## Version 0.32.1 - 17 March, 2026
+
+This is an incremental release with bug fix and enhancements.
+
+### Added
+- Added entry point to open `Hosted Agent Playground` directly from the Tree View, providing a seamless transition to test and iterate on your hosted agents after deployment.
+
+### Changed
+- Update extension description to reflect the focus on agent development and integration with Microsoft Foundry.
+
+### Fixed
+- Fixed an issue where the developers are unable to add models via Foundry Local [#364](https://github.com/microsoft/vscode-ai-toolkit/issues/364)
+
 
 ## Version 0.32.0 - 16 March, 2026
 

--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -1,5 +1,21 @@
 # What's New in Foundry Toolkit for VS Code
 
+## Version 1.4.2 - 2 June, 2026
+
+This incremental release adds **Toolbox Guardrails** for safer agent execution and expands Hosted Agent sample coverage with new LangGraph examples.
+
+### Added
+
+- **Toolbox Guardrails**: Apply guardrails to your Toolbox for safer agent execution.
+- **LangGraph Hosted Agent Samples**: Added seven LangGraph samples:
+  - [Responses API - Chat](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/langgraph/responses/01-langgraph-chat)
+  - [Responses API - MCP](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/langgraph/responses/04-mcp)
+  - [Responses API - Workflows](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/langgraph/responses/05-workflows)
+  - [Responses API - Files](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/langgraph/responses/06-files)
+  - [Responses API - Human-in-the-Loop](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/langgraph/responses/07-human-in-the-loop)
+  - [Responses API - Observability](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/langgraph/responses/08-observability)
+  - [Invocations API - Chat](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/langgraph/invocations/01-langgraph-chat)
+
 ## Version 1.4.1 - 1 June, 2026
 
 This incremental release adds model export, optimization, and quantization through WinML CLI, introduces resource usage interval updates for model profiling, aligns Windows ML with Windows App SDK 2.0, and polishes the Hosted Agent creation and deployment flow.
@@ -70,6 +86,7 @@ This release marks a major milestone: the **[Foundry Toolkit](https://marketplac
 - Improved ZIP deploy service error surfacing for clearer failure diagnostics.
 - Fixed regressions in the Hosted Agent deployment flow.
 - Fixed assorted UI regressions across Agent Builder and Playground.
+
 
 ## Version 1.2.1 - 18 May, 2026
 


### PR DESCRIPTION
## Summary

Syncs `WHATS_NEW.md` with the latest Foundry Toolkit release notes that were missing from the target branch. The current target `main` changelog is used as the baseline, with the newer release entries prepended through `Version 1.4.2`.

The existing target-main changelog content is kept intact from `Version 1.2.1` onward, so this PR only adds the newer top-level release notes.

## Validation

- Confirmed the rebuilt file matches target `main` from `Version 1.2.1` onward.
- Confirmed the final PR diff changes only `WHATS_NEW.md` with the missing top changelog entries.