### PR TITLE
docs: add outdated notice linking to official Foundry Toolkit docs

### DIFF
--- a/doc/agent-test-tool.md
+++ b/doc/agent-test-tool.md
@@ -1,5 +1,8 @@
 # Agent Inspector
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Agent Inspector](https://code.visualstudio.com/docs/intelligentapps/agent-inspector).
+
 The Agent Inspector enables developers to debug, visualize, and iterate on AI agents directly within VS Code. Press F5 to launch your agent with full debugger support, view real-time streaming responses, and visualize multi-agent workflow execution.
 
 ![Screenshot showing the Agent Inspector interface](Images/test-tool/test_tool_visualizer.png)

--- a/doc/customize.md
+++ b/doc/customize.md
@@ -1,3 +1,6 @@
 # Customize for new models
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Models](https://code.visualstudio.com/docs/intelligentapps/models).
+
 Coming soon...

--- a/doc/data_generator.md
+++ b/doc/data_generator.md
@@ -1,5 +1,8 @@
 # Data Generator
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Agent Builder](https://code.visualstudio.com/docs/intelligentapps/agentbuilder).
+
 The Data Generator is a powerful feature in the Prompt Builder that helps you create high-quality data for your prompt templates. It analyzes your prompt structure and variables to generate realistic test cases that match your expected use cases.
 
 ## How It Works

--- a/doc/evaluation.md
+++ b/doc/evaluation.md
@@ -1,3 +1,6 @@
 # Evalution with AI Toolkit
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Evaluation](https://code.visualstudio.com/docs/intelligentapps/evaluation).
+
 Coming soon...

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,5 +1,8 @@
 # AI Toolkit FAQ
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [FAQ](https://code.visualstudio.com/docs/intelligentapps/faq).
+
 ### There are too many fine-tune settings do I need to worry about all of them?
 
 No, you can just run with the default settings and our current dataset in the project to test. If you want you can also pick your own dataset but you will need to tweak some setting see [this](walkthrough-hf-dataset.md) tutorial for more info.

--- a/doc/finetune.md
+++ b/doc/finetune.md
@@ -1,5 +1,8 @@
 # Finetune models
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Fine-Tuning (Project Template)](https://code.visualstudio.com/docs/intelligentapps/finetune-legacy).
+
 # **[Preview]** Introducing Remote Development with AI Toolkit for VS Code
 
 In addition to local development, the AI Toolkit for VS Code now supports remote development. This feature enables users to provision for Azure Container Apps to run model fine-tuning and inference endpoint in the cloud.

--- a/doc/get_started.md
+++ b/doc/get_started.md
@@ -1,5 +1,8 @@
 # Get Started with AI Toolkit
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Foundry Toolkit overview](https://code.visualstudio.com/docs/intelligentapps/overview).
+
 This document will guide you through a quick path to get started with a model in AI Toolkit that has minimal pre-requisite.
 
 Follow [Overview](overview.md) to install and setup the AI Toolkit for Visual Studio Code.

--- a/doc/migration-from-visualizer.md
+++ b/doc/migration-from-visualizer.md
@@ -1,5 +1,8 @@
 # Migrating from Local Agent Playground & Local Visualizer to Agent Inspector
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Migrating from Visualizer to Agent Inspector](https://code.visualstudio.com/docs/intelligentapps/reference/migrate-from-visualizer).
+
 ## Why We're Making This Change
 
 We're consolidating the **Local Agent Playground** and **Local Visualizer** into a single, unified experience called **Agent Inspector**. This transition brings significant improvements to your AI agent development workflow.

--- a/doc/models.md
+++ b/doc/models.md
@@ -1,5 +1,8 @@
 # Models in AI Toolkit
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Models](https://code.visualstudio.com/docs/intelligentapps/models).
+
 
 ## Models supported
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,5 +1,8 @@
 # Overview of AI Toolkit
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Foundry Toolkit overview](https://code.visualstudio.com/docs/intelligentapps/overview).
+
 ## What's AI Toolkit for Visual Studio Code?
 
 AI Toolkit for Visual Studio Code is an extension to help developers and AI engineers to easily build AI apps through developing and testing with generative AI models locally or in the cloud. AI Toolkit supports most genAI models on the market.

--- a/doc/playground.md
+++ b/doc/playground.md
@@ -1,5 +1,8 @@
 # Playground overview
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Playground](https://code.visualstudio.com/docs/intelligentapps/playground).
+
 Playground is where developer to interact with AI models of choice, try different prompts with different model parameter settings. For the most recent multi-modal models that supports attachment of different format, developer can also interact through playground.
 
 In AI Toolkit, click the playground or from Model Catalog to load or try in playground, the playground view will display as screenshot:

--- a/doc/prompt.md
+++ b/doc/prompt.md
@@ -1,3 +1,6 @@
 # Prompt with AI Toolkit
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Agent Builder](https://code.visualstudio.com/docs/intelligentapps/agentbuilder).
+
 Coming soon...

--- a/doc/prompt_generator.md
+++ b/doc/prompt_generator.md
@@ -1,5 +1,8 @@
 # Prompt Generator
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Agent Builder](https://code.visualstudio.com/docs/intelligentapps/agentbuilder).
+
 The prompt generator is a powerful feature in the Prompt Builder that helps you create effective prompts for language models. It uses AI to analyze your task description and generate well-structured prompts optimized for your specific needs.
 
 ## How It Works

--- a/doc/test_with_app.md
+++ b/doc/test_with_app.md
@@ -1,3 +1,6 @@
 # Test with App
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Foundry Toolkit overview](https://code.visualstudio.com/docs/intelligentapps/overview).
+
 Coming soon...

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -1,5 +1,8 @@
 # Tracing
 
+> [!IMPORTANT]
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Tracing](https://code.visualstudio.com/docs/intelligentapps/tracing).
+
 AI Toolkit hosts a local HTTP and gRPC server to collect trace data. The collector server is compatible with OTLP (OpenTelemetry Protocol) and most language model SDKs either directly support OTLP or have third-party instrumentation libraries to support it. After collecting the instrumentation data, AI Toolkit provides a friendly UI to visualize the data.
 
 All frameworks or SDKs that support OTLP and follow [semantic conventions for generative AI systems](https://opentelemetry.io/docs/specs/semconv/gen-ai/) are supported. The following table contains common AI SDKs that we have tested.


### PR DESCRIPTION
## Why

The Markdown docs under `doc/` predate the move to the official documentation site and are no longer kept up to date (the product has since been renamed from "AI Toolkit" to "Foundry Toolkit for VS Code"). Readers landing on these pages have no signal that the content is stale or where to find the current version.

## What

Adds a GitHub `[!IMPORTANT]` alert directly under the H1 of every doc in `doc/`, telling readers the page is outdated and no longer maintained, and linking to the corresponding page on https://code.visualstudio.com/docs/intelligentapps/. Where a one-to-one page exists the link is deep-routed; for stubs and pages without an exact equivalent it points to the closest relevant page.

Page mapping used (verified against the live `intelligentapps` site navigation):

| Doc(s) | Official page |
|---|---|
| `overview`, `get_started`, `test_with_app` | overview |
| `models`, `customize` | models |
| `playground` | playground |
| `prompt`, `prompt_generator`, `data_generator` | agentbuilder (formerly Prompt Builder) |
| `agent-test-tool` | agent-inspector |
| `migration-from-visualizer` | reference/migrate-from-visualizer |
| `evaluation` | evaluation |
| `tracing` | tracing |
| `finetune` | finetune-legacy |
| `faq` | faq |

## Notes for reviewers

- `finetune.md` routes to `finetune-legacy` (Azure Container Apps "scaffold a fine-tune project" workflow), since the current `finetune` page now covers Phi Silica LoRA, a different topic.
- `test_with_app` and `customize` are "Coming soon" stubs with no exact counterpart, so they point to the nearest relevant page (overview and models respectively).
- Content-only change: 15 files, +45 lines, no code touched.