### PR TITLE
docs: also link LoRA fine-tuning page in finetune.md outdated notice

### DIFF
--- a/doc/finetune.md
+++ b/doc/finetune.md
@@ -1,7 +1,7 @@
 # Finetune models
 
 > [!IMPORTANT]
-> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Fine-Tuning (Project Template)](https://code.visualstudio.com/docs/intelligentapps/finetune-legacy).
+> This documentation is outdated and no longer maintained. For the latest information, see the official Foundry Toolkit for Visual Studio Code documentation: [Fine-Tuning (Project Template)](https://code.visualstudio.com/docs/intelligentapps/finetune-legacy) and [LoRA fine-tuning for Phi Silica](https://code.visualstudio.com/docs/intelligentapps/finetune).
 
 # **[Preview]** Introducing Remote Development with AI Toolkit for VS Code
 


### PR DESCRIPTION
## Why

Follow-up to #495, which was merged before a review comment could be addressed. On `doc/finetune.md`, reviewer feedback asked to also link the LoRA fine-tuning page (https://code.visualstudio.com/docs/intelligentapps/finetune) in addition to the project-template page. Since #495 was already merged, this change ships the fix in a new PR.

## What

Updates the outdated-doc notice in `doc/finetune.md` to link both official fine-tuning pages so readers can find either path:

- [Fine-Tuning (Project Template)](https://code.visualstudio.com/docs/intelligentapps/finetune-legacy) - matches this doc's Azure Container Apps "scaffold a fine-tune project" workflow.
- [LoRA fine-tuning for Phi Silica](https://code.visualstudio.com/docs/intelligentapps/finetune) - the current `finetune` page topic.

One-line, docs-only change.