### PR TITLE
feat(sample-catalog): map invocations_ws protocol to 'Invocations (WebSocket)'

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -74,6 +74,7 @@ const DIMENSION_DEFAULTS = {
         options: {
             responses: 'Responses API',
             invocations: 'Invocations API',
+            invocations_ws: 'Invocations (WebSocket)',
         },
     },
 };


### PR DESCRIPTION
## What

Adds a displayName mapping for the `invocations_ws` protocol id in the sample-catalog generator so the template picker shows **Invocations (WebSocket)** instead of the raw id `invocations_ws`.

## Why

The protocol dimension in `DIMENSION_DEFAULTS` only mapped `responses` and `invocations`. Any other discovered protocol id (like `invocations_ws`) fell back to rendering the raw id, which looked unpolished in the UI.

## Changes

- `.github/scripts/generate_sample_catalog.mjs`: added `invocations_ws: 'Invocations (WebSocket)'` to the protocol options.

## Notes

The generated `samples/hosted-agent/sample-catalog.json` is intentionally left untouched — it is regenerated by the CI sync workflow, which will pick up the new displayName on its next run.