### PR TITLE
fix(sample-catalog): make LLM description request compatible with newer models

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -399,6 +399,11 @@ async function fetchAzureYaml(samplePath, ref) {
 const AZURE_OPENAI_ENDPOINT = process.env.AZURE_OPENAI_ENDPOINT || '';
 const AZURE_OPENAI_API_KEY = process.env.AZURE_OPENAI_API_KEY || '';
 const AZURE_OPENAI_DEPLOYMENT = process.env.AZURE_OPENAI_DEPLOYMENT || 'gpt-4o-mini';
+// Must be >= 2024-09-01-preview so `max_completion_tokens` is accepted. Newer
+// models (gpt-5.x / reasoning) reject the legacy `max_tokens` param and any
+// non-default `temperature`; override via env if your deployment needs a
+// newer api-version.
+const AZURE_OPENAI_API_VERSION = process.env.AZURE_OPENAI_API_VERSION || '2024-10-21';
 
 /**
  * Fetch README.md content for a sample directory.
@@ -431,7 +436,7 @@ async function generateWithLLM(readmeContent, samplePath) {
         return null;
     }
 
-    const apiUrl = `${AZURE_OPENAI_ENDPOINT}/openai/deployments/${AZURE_OPENAI_DEPLOYMENT}/chat/completions?api-version=2024-08-01-preview`;
+    const apiUrl = `${AZURE_OPENAI_ENDPOINT}/openai/deployments/${AZURE_OPENAI_DEPLOYMENT}/chat/completions?api-version=${AZURE_OPENAI_API_VERSION}`;
 
     const systemPrompt = `You generate one-sentence descriptions for a VS Code template picker.
 The user has already selected language, framework, and protocol before seeing these items, so the description must NOT repeat those choices.
@@ -461,8 +466,12 @@ ${readmeContent.substring(0, 2000)}`;
             { role: 'system', content: systemPrompt },
             { role: 'user', content: userPrompt },
         ],
-        temperature: 0,
-        max_tokens: 120,
+        // `max_completion_tokens` (not the legacy `max_tokens`) so newer models
+        // accept the request. Kept generous because reasoning models spend part
+        // of the budget on hidden reasoning tokens before emitting the sentence.
+        // `temperature` is intentionally omitted: several newer models only
+        // support the default value and 400 on anything else.
+        max_completion_tokens: 800,
     };
 
     try {
@@ -476,7 +485,16 @@ ${readmeContent.substring(0, 2000)}`;
         });
 
         if (!response.ok) {
-            warn(`LLM API returned ${response.status} for ${samplePath}; description will be left empty.`);
+            // Include a truncated response body so the exact reason (e.g. an
+            // unsupported param, a missing deployment, or a wrong endpoint) is
+            // visible in the CI log instead of a bare status code.
+            let detail = '';
+            try {
+                detail = (await response.text()).replace(/\s+/g, ' ').trim().slice(0, 400);
+            } catch {
+                // ignore body read failures
+            }
+            warn(`LLM API returned ${response.status} for ${samplePath}; description will be left empty.${detail ? ` Response: ${detail}` : ''}`);
             return null;
         }
 


### PR DESCRIPTION
## Problem

The Sync Sample Catalog run [28846102061](https://github.com/microsoft/foundry-toolkit/actions/runs/28846102061) logged **`LLM API returned 400`** for **90 of 91** templates, so descriptions were left empty.

400 (not 401/404) with all templates failing means auth and routing succeeded but the **request body was rejected** — the classic newer-model (gpt-5.x / reasoning) incompatibility with the legacy chat-completions params.

## Fix

In `.github/scripts/generate_sample_catalog.mjs` (`generateWithLLM`):

- Use **`max_completion_tokens`** instead of the legacy `max_tokens` (newer models 400 on `max_tokens`).
- **Omit `temperature`** — several newer models only accept the default value and 400 on anything else.
- Bump the default **api-version to `2024-10-21`** (must be ≥ `2024-09-01-preview` for `max_completion_tokens`) and make it overridable via a new `AZURE_OPENAI_API_VERSION` env var.
- On failure, **log a truncated response body** so the exact 400 reason is visible in CI instead of a bare status code.

## Note on configuration

If descriptions still come back empty after this, check the run log for the new `Response: ...` detail, and verify the `AZURE_OPENAI_ENDPOINT` secret is the **account/AOAI endpoint** (e.g. `https://<resource>.services.ai.azure.com`) — **not** a project endpoint (the `.../api/projects/<project>` form), which is not a valid `/openai/deployments/.../chat/completions` route.

The 400 failures don't fail the build (descriptions are just left empty and flagged), so this is a quality fix, not a build blocker. The generated `sample-catalog.json` is not included; CI regenerates it.
