### PR TITLE
fix(sample-catalog): stop silently dropping LLM descriptions on reasoning models

### DIFF
--- a/.github/scripts/generate_sample_catalog.mjs
+++ b/.github/scripts/generate_sample_catalog.mjs
@@ -404,6 +404,18 @@ const AZURE_OPENAI_DEPLOYMENT = process.env.AZURE_OPENAI_DEPLOYMENT || 'gpt-4o-m
 // non-default `temperature`; override via env if your deployment needs a
 // newer api-version.
 const AZURE_OPENAI_API_VERSION = process.env.AZURE_OPENAI_API_VERSION || '2024-10-21';
+// Reasoning models (gpt-5.x / o-series) spend part of the completion budget on
+// hidden reasoning tokens BEFORE emitting any visible content. If the budget
+// is too small the reasoning alone exhausts it and `message.content` comes
+// back EMPTY (finish_reason: "length"), which is why a too-low value silently
+// dropped ~1/4 of descriptions. The visible output is a single short sentence,
+// so a generous budget costs little but leaves ample headroom for reasoning.
+const AZURE_OPENAI_MAX_COMPLETION_TOKENS = Number(process.env.AZURE_OPENAI_MAX_COMPLETION_TOKENS) || 2000;
+// Optional: cap the hidden reasoning for a trivial summarization task. Only
+// sent when set, because non-reasoning deployments (and older api-versions)
+// 400 on an unknown `reasoning_effort` param. For gpt-5.x use `minimal`; for
+// o-series use `low`.
+const AZURE_OPENAI_REASONING_EFFORT = process.env.AZURE_OPENAI_REASONING_EFFORT || '';
 
 /**
  * Fetch README.md content for a sample directory.
@@ -461,6 +473,7 @@ Respond ONLY with a JSON object: {"description": "..."}`;
 README.md:
 ${readmeContent.substring(0, 2000)}`;
 
+    /** @type {{ messages: Array<{role: string, content: string}>, max_completion_tokens: number, reasoning_effort?: string }} */
     const body = {
         messages: [
             { role: 'system', content: systemPrompt },
@@ -471,8 +484,11 @@ ${readmeContent.substring(0, 2000)}`;
         // of the budget on hidden reasoning tokens before emitting the sentence.
         // `temperature` is intentionally omitted: several newer models only
         // support the default value and 400 on anything else.
-        max_completion_tokens: 800,
+        max_completion_tokens: AZURE_OPENAI_MAX_COMPLETION_TOKENS,
     };
+    if (AZURE_OPENAI_REASONING_EFFORT) {
+        body.reasoning_effort = AZURE_OPENAI_REASONING_EFFORT;
+    }
 
     try {
         const response = await fetch(apiUrl, {
@@ -499,8 +515,17 @@ ${readmeContent.substring(0, 2000)}`;
         }
 
         const data = await response.json();
-        const content = data.choices?.[0]?.message?.content?.trim();
+        const choice = data.choices?.[0];
+        const content = choice?.message?.content?.trim();
         if (!content) {
+            // A successful (200) call with empty content is almost always a
+            // reasoning model exhausting `max_completion_tokens` on hidden
+            // reasoning (finish_reason: "length"). Surface it instead of
+            // silently leaving the description empty, and hint at the knobs.
+            const finishReason = choice?.finish_reason ?? 'unknown';
+            const reasoningTokens = data.usage?.completion_tokens_details?.reasoning_tokens;
+            const usageHint = reasoningTokens !== undefined ? ` (reasoning_tokens=${reasoningTokens})` : '';
+            warn(`LLM returned empty content for ${samplePath} (finish_reason=${finishReason}${usageHint}); description left empty. If finish_reason is "length", raise AZURE_OPENAI_MAX_COMPLETION_TOKENS or set AZURE_OPENAI_REASONING_EFFORT.`);
             return null;
         }
 
@@ -510,6 +535,7 @@ ${readmeContent.substring(0, 2000)}`;
 
         const description = typeof parsed.description === 'string' ? parsed.description.trim() : '';
         if (!description) {
+            warn(`LLM response for ${samplePath} had no usable "description" field; description left empty.`);
             return null;
         }
 


### PR DESCRIPTION
## Problem

After #522 fixed the `400` errors, the sync run [28846883377](https://github.com/microsoft/foundry-toolkit/actions/runs/28846883377) still left **26 of 91** descriptions empty — with **no error in the log** (no `400`, no `LLM call failed`).

### Root cause

The deployment is a **reasoning model** (gpt-5.x / o-series):

- The LLM phase took ~8 s/template (a non-reasoning `gpt-4o-mini` is ~1-2 s) — extended hidden reasoning.
- Reasoning models spend the completion budget on **hidden reasoning tokens before emitting any visible content**. With `max_completion_tokens: 800`, ~1/4 of the templates exhausted the budget on reasoning alone and returned **empty content** (`finish_reason: "length"`).
- `generateWithLLM` returned `null` on empty content (and on a missing `description` field) **without logging anything**, so the failures were invisible and the descriptions were silently left blank.

## Fix

In `.github/scripts/generate_sample_catalog.mjs` (`generateWithLLM`):

- **Raise the default budget to 2000 tokens** (the visible output is a single sentence, so headroom is cheap). Overridable via `AZURE_OPENAI_MAX_COMPLETION_TOKENS`.
- **Add optional `AZURE_OPENAI_REASONING_EFFORT`** — only sent when set (non-reasoning models `400` on the param). Set it to `minimal` (gpt-5.x) or `low` (o-series) to cut the hidden reasoning for this trivial summarization task.
- **Emit a diagnostic warning instead of silently returning null** for both the empty-content path (including `finish_reason` and `reasoning_tokens`) and the missing-`description` path, so any remaining gaps are visible in the CI step summary.

## Recommendation for the operator

For fastest, most reliable results with the current reasoning deployment, set repo variable/secret **`AZURE_OPENAI_REASONING_EFFORT=minimal`** (gpt-5.x). The 2000-token default already resolves the truncation without it; the knob mainly reduces latency/cost.

The generated `sample-catalog.json` is not included; CI regenerates it on the next sync run.
