### PR TITLE
ci: update sample catalog commitSha to c14a01b

### DIFF
--- a/samples/hosted-agent/sample-catalog.json
+++ b/samples/hosted-agent/sample-catalog.json
@@ -1,5 +1,5 @@
 {
-    "commitSha": "9c4e42a1eedcec32c1582bebeb83a381a23efbe1",
+    "commitSha": "c14a01b61eb6a59aeae140f7db07b420f85fcfb4",
     "repo": "https://github.com/microsoft-foundry/foundry-samples/",
     "generatedAt": "2026-07-07T06:19:12Z",
     "dimensions": {


### PR DESCRIPTION
Updates the pinned commitSha in samples/hosted-agent/sample-catalog.json to the latest upstream commit.

Changes:
- commitSha: 19b441d474ec963c61a509692fdd81d5fb707d71 → c14a01b61eb6a59aeae140f7db07b420f85fcfb4

Reviewer Checks:
- Confirm the new commit SHA points to a valid commit in microsoft-foundry/foundry-samples.
- Verify that sample templates at this SHA are compatible with the current catalog schema.