### PR TITLE
ci: add Foundry Agent Canvas sync workflow

### DIFF
--- a/.github/scripts/sync_foundry_agent_canvas.mjs
+++ b/.github/scripts/sync_foundry_agent_canvas.mjs
@@ -13,9 +13,9 @@ import { join, resolve } from "node:path";
 const [sourceArg, targetArg, pluginManifestArg, nextVersion] =
   process.argv.slice(2);
 
-if (!sourceArg || !targetArg || !pluginManifestArg || !nextVersion) {
+if (!sourceArg || !targetArg || !pluginManifestArg) {
   throw new Error(
-    "Usage: sync_foundry_agent_canvas.mjs <source-package> <target-extension> <plugin-manifest> <version>",
+    "Usage: sync_foundry_agent_canvas.mjs <source-package> <target-extension> <plugin-manifest> [version]",
   );
 }
 
@@ -75,15 +75,20 @@ if (extensionManifest.name !== "foundry-agent-canvas") {
   throw new Error(`Unexpected extension name: ${extensionManifest.name}`);
 }
 
-const currentParsedVersion = parseVersion(
-  pluginManifest.version,
-  "Current plugin version",
-);
-const nextParsedVersion = parseVersion(nextVersion, "Requested plugin version");
-if (compareVersions(nextParsedVersion, currentParsedVersion) <= 0) {
-  throw new Error(
-    `Requested plugin version ${nextVersion} must be newer than ${pluginManifest.version}`,
+if (nextVersion) {
+  const currentParsedVersion = parseVersion(
+    pluginManifest.version,
+    "Current plugin version",
   );
+  const nextParsedVersion = parseVersion(
+    nextVersion,
+    "Requested plugin version",
+  );
+  if (compareVersions(nextParsedVersion, currentParsedVersion) <= 0) {
+    throw new Error(
+      `Requested plugin version ${nextVersion} must be newer than ${pluginManifest.version}`,
+    );
+  }
 }
 
 for (const entry of payload) {
@@ -97,12 +102,17 @@ for (const entry of payload) {
   });
 }
 
-pluginManifest.version = nextVersion;
-writeFileSync(
-  pluginManifestPath,
-  `${JSON.stringify(pluginManifest, null, 2)}\n`,
-);
-
-console.log(
-  `Synced foundry-agent-canvas payload and updated plugin version to ${nextVersion}`,
-);
+if (nextVersion) {
+  pluginManifest.version = nextVersion;
+  writeFileSync(
+    pluginManifestPath,
+    `${JSON.stringify(pluginManifest, null, 2)}\n`,
+  );
+  console.log(
+    `Synced foundry-agent-canvas payload and updated plugin version to ${nextVersion}`,
+  );
+} else {
+  console.log(
+    `Synced foundry-agent-canvas payload and preserved plugin version ${pluginManifest.version}`,
+  );
+}

--- a/.github/scripts/sync_foundry_agent_canvas.mjs
+++ b/.github/scripts/sync_foundry_agent_canvas.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import {
+  cpSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+const [sourceArg, targetArg, pluginManifestArg, nextVersion] =
+  process.argv.slice(2);
+
+if (!sourceArg || !targetArg || !pluginManifestArg || !nextVersion) {
+  throw new Error(
+    "Usage: sync_foundry_agent_canvas.mjs <source-package> <target-extension> <plugin-manifest> <version>",
+  );
+}
+
+const sourceRoot = resolve(sourceArg);
+const targetRoot = resolve(targetArg);
+const pluginManifestPath = resolve(pluginManifestArg);
+const extensionManifestPath = join(targetRoot, "package.json");
+const payload = [
+  { path: "extension.mjs", type: "file" },
+  { path: "public", type: "directory" },
+  { path: "inspector-ui", type: "directory" },
+];
+
+function parseVersion(value, label) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
+  if (!match) {
+    throw new Error(`${label} must use stable X.Y.Z semantic versioning`);
+  }
+
+  return match.slice(1).map(Number);
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+
+  return 0;
+}
+
+for (const entry of payload) {
+  const sourcePath = join(sourceRoot, entry.path);
+  if (!existsSync(sourcePath)) {
+    throw new Error(`Missing packaged payload: ${sourcePath}`);
+  }
+
+  const sourceStat = statSync(sourcePath);
+  if (
+    (entry.type === "file" && !sourceStat.isFile()) ||
+    (entry.type === "directory" && !sourceStat.isDirectory())
+  ) {
+    throw new Error(`Packaged payload has the wrong type: ${sourcePath}`);
+  }
+}
+
+const pluginManifest = JSON.parse(readFileSync(pluginManifestPath, "utf8"));
+if (pluginManifest.name !== "foundry-agent-canvas") {
+  throw new Error(`Unexpected plugin name: ${pluginManifest.name}`);
+}
+
+const extensionManifest = JSON.parse(
+  readFileSync(extensionManifestPath, "utf8"),
+);
+if (extensionManifest.name !== "foundry-agent-canvas") {
+  throw new Error(`Unexpected extension name: ${extensionManifest.name}`);
+}
+
+const currentParsedVersion = parseVersion(
+  pluginManifest.version,
+  "Current plugin version",
+);
+const nextParsedVersion = parseVersion(nextVersion, "Requested plugin version");
+if (compareVersions(nextParsedVersion, currentParsedVersion) <= 0) {
+  throw new Error(
+    `Requested plugin version ${nextVersion} must be newer than ${pluginManifest.version}`,
+  );
+}
+
+for (const entry of payload) {
+  const sourcePath = join(sourceRoot, entry.path);
+  const targetPath = join(targetRoot, entry.path);
+
+  rmSync(targetPath, { recursive: true, force: true });
+  cpSync(sourcePath, targetPath, {
+    recursive: entry.type === "directory",
+    force: true,
+  });
+}
+
+pluginManifest.version = nextVersion;
+writeFileSync(
+  pluginManifestPath,
+  `${JSON.stringify(pluginManifest, null, 2)}\n`,
+);
+
+console.log(
+  `Synced foundry-agent-canvas payload and updated plugin version to ${nextVersion}`,
+);

--- a/.github/workflows/sync-foundry-agent-canvas.yml
+++ b/.github/workflows/sync-foundry-agent-canvas.yml
@@ -9,12 +9,16 @@ on:
         default: "main"
         type: string
       marketplace_version:
-        description: "New marketplace version using stable X.Y.Z format"
-        required: true
+        description: "Optional new marketplace version using stable X.Y.Z format"
+        required: false
         type: string
 
 permissions:
   contents: read
+
+env:
+  CANVAS_SOURCE_REF: ${{ inputs.source_ref || 'main' }}
+  MARKETPLACE_VERSION: ${{ inputs.marketplace_version || '' }}
 
 concurrency:
   group: sync-foundry-agent-canvas
@@ -34,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: SmallBlackHole/foundry-agent-canvas
-          ref: ${{ inputs.source_ref }}
+          ref: ${{ env.CANVAS_SOURCE_REF }}
           path: source
           persist-credentials: false
 
@@ -92,6 +96,13 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout workflow automation
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: automation
+          persist-credentials: false
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -115,11 +126,35 @@ jobs:
 
       - name: Sync runtime package
         run: |
-          node target/.github/scripts/sync_foundry_agent_canvas.mjs \
+          node automation/.github/scripts/sync_foundry_agent_canvas.mjs \
             bundle \
             target/foundry-agent-canvas/extensions/foundry-agent-canvas \
             target/foundry-agent-canvas/.github/plugin/plugin.json \
-            "${{ inputs.marketplace_version }}"
+            "$MARKETPLACE_VERSION"
+
+      - name: Resolve pull request metadata
+        id: metadata
+        shell: bash
+        env:
+          SOURCE_SHORT_SHA: ${{ needs.build.outputs.source_short_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "$MARKETPLACE_VERSION" ]]; then
+            branch_suffix="v$MARKETPLACE_VERSION"
+            title="chore: sync foundry-agent-canvas v$MARKETPLACE_VERSION"
+            version_label="$MARKETPLACE_VERSION"
+          else
+            branch_suffix="$SOURCE_SHORT_SHA"
+            title="chore: sync foundry-agent-canvas ($SOURCE_SHORT_SHA)"
+            version_label="unchanged"
+          fi
+
+          {
+            echo "branch_suffix=$branch_suffix"
+            echo "title=$title"
+            echo "version_label=$version_label"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Detect package changes
         id: diff
@@ -146,7 +181,7 @@ jobs:
             echo "## Foundry Agent Canvas Sync"
             echo
             echo "- Source: \`SmallBlackHole/foundry-agent-canvas@${{ needs.build.outputs.source_sha }}\`"
-            echo "- Marketplace version: \`${{ inputs.marketplace_version }}\`"
+            echo "- Marketplace version: \`${{ steps.metadata.outputs.version_label }}\`"
             echo
             echo "### Changed files"
             echo
@@ -163,20 +198,20 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: target
           base: main
-          branch: bot/sync-foundry-agent-canvas-v${{ inputs.marketplace_version }}
+          branch: bot/sync-foundry-agent-canvas-${{ steps.metadata.outputs.branch_suffix }}
           delete-branch: true
           draft: always-true
-          commit-message: "chore: sync foundry-agent-canvas v${{ inputs.marketplace_version }}"
-          title: "chore: sync foundry-agent-canvas v${{ inputs.marketplace_version }}"
+          commit-message: ${{ steps.metadata.outputs.title }}
+          title: ${{ steps.metadata.outputs.title }}
           body: |
             ## Summary
             This automated draft PR updates the bundled Foundry Agent Canvas runtime.
 
             ## Source
             - Repository: `SmallBlackHole/foundry-agent-canvas`
-            - Requested ref: `${{ inputs.source_ref }}`
+            - Requested ref: `${{ env.CANVAS_SOURCE_REF }}`
             - Resolved commit: `${{ needs.build.outputs.source_sha }}`
-            - Marketplace version: `${{ inputs.marketplace_version }}`
+            - Marketplace version: `${{ steps.metadata.outputs.version_label }}`
             - Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ## Validation

--- a/.github/workflows/sync-foundry-agent-canvas.yml
+++ b/.github/workflows/sync-foundry-agent-canvas.yml
@@ -103,6 +103,11 @@ jobs:
           path: automation
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.19"
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -117,6 +122,7 @@ jobs:
           ref: main
           fetch-depth: 0
           path: target
+          persist-credentials: false
 
       - name: Download runtime package
         uses: actions/download-artifact@v4

--- a/.github/workflows/sync-foundry-agent-canvas.yml
+++ b/.github/workflows/sync-foundry-agent-canvas.yml
@@ -89,13 +89,20 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
       - name: Checkout foundry-toolkit
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           ref: main
           fetch-depth: 0
           path: target
@@ -153,7 +160,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
           path: target
           base: main
           branch: bot/sync-foundry-agent-canvas-v${{ inputs.marketplace_version }}

--- a/.github/workflows/sync-foundry-agent-canvas.yml
+++ b/.github/workflows/sync-foundry-agent-canvas.yml
@@ -1,0 +1,200 @@
+name: Sync Foundry Agent Canvas
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Branch, tag, or commit from SmallBlackHole/foundry-agent-canvas"
+        required: true
+        default: "main"
+        type: string
+      marketplace_version:
+        description: "New marketplace version using stable X.Y.Z format"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-foundry-agent-canvas
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+      source_short_sha: ${{ steps.source.outputs.short_sha }}
+
+    steps:
+      - name: Checkout canvas source
+        uses: actions/checkout@v4
+        with:
+          repository: SmallBlackHole/foundry-agent-canvas
+          ref: ${{ inputs.source_ref }}
+          path: source
+          persist-credentials: false
+
+      - name: Resolve source commit
+        id: source
+        working-directory: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.19"
+
+      - name: Install dependencies
+        working-directory: source
+        run: npm ci
+
+      - name: Run tests
+        working-directory: source
+        run: npm test
+
+      - name: Build package
+        working-directory: source
+        run: npm run package
+
+      - name: Validate package
+        working-directory: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f dist/pkg/extension.mjs
+          test -d dist/pkg/public
+          test -d dist/pkg/inspector-ui
+          node --check dist/pkg/extension.mjs
+
+      - name: Upload runtime package
+        uses: actions/upload-artifact@v4
+        with:
+          name: foundry-agent-canvas-${{ steps.source.outputs.short_sha }}
+          path: |
+            source/dist/pkg/extension.mjs
+            source/dist/pkg/public
+            source/dist/pkg/inspector-ui
+          if-no-files-found: error
+          retention-days: 3
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout foundry-toolkit
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          path: target
+
+      - name: Download runtime package
+        uses: actions/download-artifact@v4
+        with:
+          name: foundry-agent-canvas-${{ needs.build.outputs.source_short_sha }}
+          path: bundle
+
+      - name: Sync runtime package
+        run: |
+          node target/.github/scripts/sync_foundry_agent_canvas.mjs \
+            bundle \
+            target/foundry-agent-canvas/extensions/foundry-agent-canvas \
+            target/foundry-agent-canvas/.github/plugin/plugin.json \
+            "${{ inputs.marketplace_version }}"
+
+      - name: Detect package changes
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git -C target add -- \
+            foundry-agent-canvas/.github/plugin/plugin.json \
+            foundry-agent-canvas/extensions/foundry-agent-canvas/extension.mjs \
+            foundry-agent-canvas/extensions/foundry-agent-canvas/public \
+            foundry-agent-canvas/extensions/foundry-agent-canvas/inspector-ui
+
+          if git -C target diff --cached --quiet -- foundry-agent-canvas; then
+            echo "No package changes detected."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git -C target diff --cached --stat -- foundry-agent-canvas
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Foundry Agent Canvas Sync"
+            echo
+            echo "- Source: \`SmallBlackHole/foundry-agent-canvas@${{ needs.build.outputs.source_sha }}\`"
+            echo "- Marketplace version: \`${{ inputs.marketplace_version }}\`"
+            echo
+            echo "### Changed files"
+            echo
+            echo '```text'
+            git -C target diff --cached --name-status -- foundry-agent-canvas
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create draft pull request
+        if: steps.diff.outputs.has_changes == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ github.token }}
+          path: target
+          base: main
+          branch: bot/sync-foundry-agent-canvas-v${{ inputs.marketplace_version }}
+          delete-branch: true
+          draft: always-true
+          commit-message: "chore: sync foundry-agent-canvas v${{ inputs.marketplace_version }}"
+          title: "chore: sync foundry-agent-canvas v${{ inputs.marketplace_version }}"
+          body: |
+            ## Summary
+            This automated draft PR updates the bundled Foundry Agent Canvas runtime.
+
+            ## Source
+            - Repository: `SmallBlackHole/foundry-agent-canvas`
+            - Requested ref: `${{ inputs.source_ref }}`
+            - Resolved commit: `${{ needs.build.outputs.source_sha }}`
+            - Marketplace version: `${{ inputs.marketplace_version }}`
+            - Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            ## Validation
+            - `npm ci`
+            - `npm test`
+            - `npm run package`
+            - `node --check dist/pkg/extension.mjs`
+          add-paths: |
+            foundry-agent-canvas/.github/plugin/plugin.json
+            foundry-agent-canvas/extensions/foundry-agent-canvas/extension.mjs
+            foundry-agent-canvas/extensions/foundry-agent-canvas/public
+            foundry-agent-canvas/extensions/foundry-agent-canvas/inspector-ui
+
+      - name: Report pull request
+        if: steps.diff.outputs.has_changes == 'true'
+        shell: bash
+        env:
+          PR_OPERATION: ${{ steps.cpr.outputs.pull-request-operation }}
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          {
+            echo
+            echo "## Pull Request"
+            echo
+            echo "- Operation: \`${PR_OPERATION:-unknown}\`"
+            echo "- PR: [#${PR_NUMBER:-?}](${PR_URL})"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add a manually triggered workflow to build and package `SmallBlackHole/foundry-agent-canvas`.
- Synchronize the generated runtime payload into `foundry-agent-canvas/extensions/foundry-agent-canvas`.
- Open a draft package-update PR through the existing `foundry-toolkit-sync-bot` GitHub App.
- Make the marketplace version optional; when omitted, preserve `.github/plugin/plugin.json` and identify the PR by source commit.

## Security
- Keep the default `GITHUB_TOKEN` read-only.
- Generate the App installation token only in the publish job, after the source build and tests complete.
- Use the App token for target checkout and pull-request creation.

## Validation
- Source test suite and package build passed.
- Workflow YAML parsing and `actionlint` passed.
- Versioned and no-version sync paths passed local dry runs.
- E2E workflow run `29976402683` completed successfully.
- The E2E run created draft PR #572 as `foundry-toolkit-sync-bot`, preserved marketplace version `1.0.2`, and changed only bundled runtime files; the test PR and temporary branches were then removed.

## Trigger
This workflow supports `workflow_dispatch` only. It has no push, pull request, schedule, or repository dispatch trigger.