### PR TITLE
chore: update microsoft-foundry metadata

### DIFF
--- a/.github/workflows/sync-microsoft-foundry.yml
+++ b/.github/workflows/sync-microsoft-foundry.yml
@@ -1,4 +1,4 @@
-name: Sync Microsoft Foundry
+name: Sync microsoft-foundry canvas
 
 on:
   workflow_dispatch:
@@ -187,7 +187,7 @@ jobs:
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
           {
-            echo "## Microsoft Foundry Sync"
+            echo "## Sync microsoft-foundry canvas"
             echo
             echo "- Source: \`SmallBlackHole/foundry-agent-canvas@${{ needs.build.outputs.source_sha }}\`"
             echo "- Marketplace version: \`${{ steps.metadata.outputs.version_label }}\`"

--- a/microsoft-foundry/.github/plugin/plugin.json
+++ b/microsoft-foundry/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-foundry",
   "description": "Skills and interactive Copilot canvas for designing, configuring, testing and deploying agents to Microsoft Foundry.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Microsoft",
     "url": "https://github.com/microsoft"

--- a/microsoft-foundry/.github/plugin/plugin.json
+++ b/microsoft-foundry/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "microsoft-foundry",
-  "description": "Interactive Copilot canvas for designing, configuring, testing and deploying hosted agents to Microsoft Foundry.",
+  "description": "Skills and interactive Copilot canvas for designing, configuring, testing and deploying agents to Microsoft Foundry.",
   "version": "1.0.2",
   "author": {
     "name": "Microsoft",

--- a/microsoft-foundry/README.md
+++ b/microsoft-foundry/README.md
@@ -1,4 +1,4 @@
-# Microsoft Foundry
+# Microsoft Foundry Canvas
 
 A GitHub Copilot App canvas extension for designing Microsoft Foundry hosted
 agents from a side panel. It combines live Foundry project discovery with


### PR DESCRIPTION
## Summary

Follow-up metadata alignment after the `microsoft-foundry` rename (#587) and sync (#588). Three minimal changes, all identity/branding metadata.

## Changes

1. **Plugin manifest description** (`microsoft-foundry/.github/plugin/plugin.json`) -> `Skills and interactive Copilot canvas for designing, configuring, testing and deploying agents to Microsoft Foundry.` Aligns `plugin.json` with the synced extension `package.json` description (already on `main` via #588's sync of `db4a09a`); the sync workflow never touches `plugin.json`, so it had the prior wording.
2. **Sync workflow display name** (`.github/workflows/sync-microsoft-foundry.yml`) -> `Sync microsoft-foundry canvas` (workflow `name:` and the job summary heading `## Sync microsoft-foundry canvas`). No file rename or internal identifier changes.
3. **README H1** (`microsoft-foundry/README.md`) -> `# Microsoft Foundry Canvas`.

No other plugin/canvas display names or unrelated files changed. Vendored payload untouched.

## Validation

- JSON parse of `plugin.json` and extension `package.json` -> both descriptions read back byte-exact and identical.
- `yaml.safe_load` on the workflow -> valid; `name` = `Sync microsoft-foundry canvas`.
- Grep confirms no stale `Sync Microsoft Foundry` / `Microsoft Foundry Sync` / prior description text remains in authored files.
- Diff vs `origin/main` contains only the three intended files.

## Commits

- `f4e40a9` - chore: update microsoft-foundry plugin description and sync workflow name
- `1ba814a` - docs: update microsoft-foundry README title
