### PR TITLE
docs: add changelog site published to GitHub Pages

### DIFF
--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -1,0 +1,61 @@
+name: Publish Changelog Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'WHATS_NEW.md'
+      - 'site/**'
+      - '.github/workflows/publish-changelog.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Allow one publish at a time; queued runs wait so the live site always
+# reflects the newest commit rather than a cancelled mid-deploy state.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: site
+        run: npm install --no-audit --no-fund
+
+      - name: Build changelog site
+        working-directory: site
+        run: npm run build
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,33 @@
+# Changelog site
+
+A static changelog page generated from [`WHATS_NEW.md`](../WHATS_NEW.md) and published to
+GitHub Pages by [`publish-changelog.yml`](../.github/workflows/publish-changelog.yml).
+
+`WHATS_NEW.md` stays the single source of truth — edit releases there, never in this folder.
+
+## Local development
+
+```bash
+cd site
+npm install
+npm run build      # writes site/dist
+npx http-server dist -p 8099 -c-1
+```
+
+`site/dist` and `site/node_modules` are git-ignored; the site is built in CI on every push.
+
+## How it works
+
+- `build.mjs` splits `WHATS_NEW.md` on each `## Version <version> - <date>` heading, renders
+  each release body with [marked](https://marked.js.org/), and emits a single `index.html`
+  with a version sidebar.
+- `assets/styles.css` and `assets/app.js` are copied verbatim into `dist`. The script adds
+  filtering (press `/` to focus), scroll-spy nav highlighting, and a light/dark toggle.
+- `### Added` / `Changed` / `Fixed` / `Removed` / `Deprecated` / `Security` headings inside a
+  release become summary chips; other headings render normally.
+- A `.nojekyll` marker is emitted so Pages serves the output as-is.
+
+## One-time repository setup
+
+In **Settings → Pages**, set **Source** to **GitHub Actions**. The workflow then deploys on
+every push to `main` that touches `WHATS_NEW.md` or `site/`, and via **Run workflow**.

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1,0 +1,155 @@
+(function () {
+  'use strict';
+
+  var THEME_KEY = 'foundry-toolkit-changelog-theme';
+  var root = document.documentElement;
+  var toggle = document.getElementById('theme-toggle');
+  var icon = toggle ? toggle.querySelector('[data-theme-icon]') : null;
+  var search = document.getElementById('search');
+  var results = document.getElementById('results');
+  var navEmpty = document.getElementById('nav-empty');
+  var contentEmpty = document.getElementById('content-empty');
+  var releases = Array.prototype.slice.call(document.querySelectorAll('.release'));
+  var navItems = Array.prototype.slice.call(document.querySelectorAll('.nav__item'));
+
+  // Theme
+
+  function applyTheme(theme) {
+    root.setAttribute('data-theme', theme);
+    if (icon) {
+      icon.textContent = theme === 'dark' ? '☀' : '☾';
+    }
+    if (toggle) {
+      toggle.setAttribute('aria-label', theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme');
+    }
+  }
+
+  function readStoredTheme() {
+    try {
+      return window.localStorage.getItem(THEME_KEY);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  var stored = readStoredTheme();
+  var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  applyTheme(stored || (prefersDark ? 'dark' : 'light'));
+
+  if (toggle) {
+    toggle.addEventListener('click', function () {
+      var next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      applyTheme(next);
+      try {
+        window.localStorage.setItem(THEME_KEY, next);
+      } catch (error) {
+        /* Storage can be blocked; the theme still applies for this page view. */
+      }
+    });
+  }
+
+  // Filtering
+
+  var searchIndex = releases.map(function (release) {
+    return {
+      element: release,
+      id: release.id,
+      text: (release.textContent || '').toLowerCase(),
+    };
+  });
+
+  function filter(query) {
+    var normalized = query.trim().toLowerCase();
+    var matchedIds = {};
+    var matches = 0;
+
+    searchIndex.forEach(function (entry) {
+      var isMatch = normalized === '' || entry.text.indexOf(normalized) !== -1;
+      entry.element.hidden = !isMatch;
+      if (isMatch) {
+        matchedIds[entry.id] = true;
+        matches += 1;
+      }
+    });
+
+    navItems.forEach(function (item) {
+      item.hidden = !matchedIds[item.getAttribute('data-target')];
+    });
+
+    document.querySelectorAll('.nav__group').forEach(function (group) {
+      var visible = group.querySelectorAll('.nav__item:not([hidden])').length;
+      group.hidden = visible === 0;
+    });
+
+    if (navEmpty) {
+      navEmpty.hidden = matches !== 0;
+    }
+    if (contentEmpty) {
+      contentEmpty.hidden = matches !== 0;
+    }
+    if (results) {
+      results.hidden = normalized === '';
+      results.textContent =
+        matches === 1 ? '1 matching release' : matches + ' matching releases';
+    }
+  }
+
+  if (search) {
+    search.addEventListener('input', function () {
+      filter(search.value);
+    });
+
+    // Restore a filter that survived a reload (e.g. browser form restoration).
+    if (search.value) {
+      filter(search.value);
+    }
+  }
+
+  document.addEventListener('keydown', function (event) {
+    if (event.key === '/' && search && document.activeElement !== search) {
+      event.preventDefault();
+      search.focus();
+    }
+  });
+
+  // Active release highlighting
+
+  function setActive(id) {
+    navItems.forEach(function (item) {
+      item.classList.toggle('is-active', item.getAttribute('data-target') === id);
+    });
+  }
+
+  if ('IntersectionObserver' in window && releases.length > 0) {
+    var visible = new Set();
+    var observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            visible.add(entry.target.id);
+          } else {
+            visible.delete(entry.target.id);
+          }
+        });
+
+        for (var i = 0; i < releases.length; i += 1) {
+          if (visible.has(releases[i].id)) {
+            setActive(releases[i].id);
+            return;
+          }
+        }
+      },
+      { rootMargin: '-96px 0px -60% 0px', threshold: 0 },
+    );
+
+    releases.forEach(function (release) {
+      observer.observe(release);
+    });
+  }
+
+  if (window.location.hash) {
+    setActive(window.location.hash.slice(1));
+  } else if (releases.length > 0) {
+    setActive(releases[0].id);
+  }
+})();

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,0 +1,448 @@
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff;
+  --bg-subtle: #f6f8fa;
+  --bg-elevated: #ffffff;
+  --border: #d7dde5;
+  --border-subtle: #e8ecf1;
+  --text: #1b1f24;
+  --text-muted: #5b6472;
+  --accent: #0a5fb4;
+  --accent-contrast: #ffffff;
+  --radius: 10px;
+  --shadow: 0 1px 2px rgba(27, 31, 36, 0.08), 0 4px 12px rgba(27, 31, 36, 0.05);
+}
+
+[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --bg-subtle: #161b22;
+  --bg-elevated: #12181f;
+  --border: #2c333c;
+  --border-subtle: #21262d;
+  --text: #e6edf3;
+  --text-muted: #9aa6b2;
+  --accent: #63a6ff;
+  --accent-contrast: #08131f;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 6px 16px rgba(0, 0, 0, 0.3);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 96px;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Segoe UI Variable', Roboto, Helvetica,
+    Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  padding: 8px 16px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  z-index: 10;
+}
+
+.skip-link:focus {
+  left: 8px;
+  top: 8px;
+}
+
+/* Masthead */
+
+.masthead {
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-subtle);
+}
+
+.masthead__inner {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 40px 24px 32px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.masthead__eyebrow {
+  margin: 0 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.masthead__title {
+  margin: 0;
+  font-size: 34px;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.masthead__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.button:hover {
+  text-decoration: none;
+  border-color: var(--accent);
+}
+
+.button--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.button--icon {
+  padding: 8px 10px;
+  min-width: 40px;
+}
+
+/* Layout */
+
+.layout {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 40px;
+  align-items: start;
+}
+
+.sidebar {
+  position: sticky;
+  top: 24px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.search input {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+}
+
+.sidebar__empty {
+  margin: 12px 2px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.nav__group {
+  margin-top: 22px;
+}
+
+.nav__group-title {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-left: 1px solid var(--border-subtle);
+}
+
+.nav__item a {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 12px;
+  margin-left: -1px;
+  border-left: 2px solid transparent;
+  color: var(--text);
+  font-size: 14px;
+}
+
+.nav__item a:hover {
+  text-decoration: none;
+  background: var(--bg-subtle);
+}
+
+.nav__item.is-active a {
+  border-left-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.nav__date {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.nav__item.is-active .nav__date {
+  color: var(--text-muted);
+}
+
+/* Content */
+
+.content {
+  min-width: 0;
+}
+
+.intro {
+  margin-bottom: 24px;
+  color: var(--text-muted);
+}
+
+.results {
+  margin: 0 0 16px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.content__empty {
+  padding: 40px 0;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.release {
+  padding: 24px;
+  margin-bottom: 20px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow);
+}
+
+.release__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 16px;
+  justify-content: space-between;
+}
+
+.release__title {
+  margin: 0;
+  font-size: 24px;
+  letter-spacing: -0.01em;
+  position: relative;
+}
+
+.release__anchor {
+  position: absolute;
+  left: -22px;
+  color: var(--text-muted);
+  opacity: 0;
+  font-weight: 400;
+}
+
+.release:hover .release__anchor,
+.release__anchor:focus-visible {
+  opacity: 1;
+}
+
+.badge {
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font-size: 12px;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
+.release__date {
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.release__body h3 {
+  margin: 22px 0 8px;
+  font-size: 15px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.release__body h4 {
+  margin: 16px 0 6px;
+  font-size: 15px;
+}
+
+.release__body ul {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.release__body li {
+  margin: 4px 0;
+}
+
+.release__body p {
+  margin: 10px 0;
+}
+
+.release__body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius);
+}
+
+.release__body code {
+  padding: 0.15em 0.4em;
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-subtle);
+  font-family: ui-monospace, SFMono-Regular, 'Cascadia Mono', Consolas, monospace;
+  font-size: 0.88em;
+}
+
+.release__body pre {
+  padding: 14px 16px;
+  overflow-x: auto;
+  border-radius: var(--radius);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-subtle);
+}
+
+.release__body pre code {
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.release__body table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 12px 0;
+  font-size: 15px;
+}
+
+.release__body th,
+.release__body td {
+  border: 1px solid var(--border-subtle);
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.release__body blockquote {
+  margin: 12px 0;
+  padding: 4px 16px;
+  border-left: 3px solid var(--border);
+  color: var(--text-muted);
+}
+
+.footer {
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-subtle);
+}
+
+.footer p {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 20px 24px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 24px;
+  }
+
+  .sidebar {
+    position: static;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 24px;
+  }
+
+  .release__anchor {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -1,0 +1,301 @@
+// Builds the static changelog site published to GitHub Pages.
+// Source of truth is WHATS_NEW.md at the repository root; this script only
+// transforms it, so the markdown file stays the single place releases are edited.
+
+import { mkdir, readFile, readdir, writeFile, cp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { marked } from 'marked';
+
+const siteDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(siteDir, '..');
+const sourceFile = join(repoRoot, 'WHATS_NEW.md');
+const outDir = join(siteDir, 'dist');
+
+const REPO_URL = 'https://github.com/microsoft/foundry-toolkit';
+const MARKETPLACE_URL =
+  'https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio';
+const SITE_TITLE = 'Foundry Toolkit for VS Code';
+const SITE_DESCRIPTION = 'Release notes and changelog for the Foundry Toolkit for VS Code extension.';
+
+marked.setOptions({ gfm: true, breaks: false });
+
+/** Escapes a string for interpolation into HTML text or a quoted attribute. */
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Splits WHATS_NEW.md into an intro block plus one entry per `## Version ...`
+ * heading, keeping each release body as raw markdown for later rendering.
+ */
+function parseChangelog(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const releases = [];
+  let intro = [];
+  let current = null;
+
+  for (const line of lines) {
+    const versionHeading = /^##\s+(.*\S)\s*$/.exec(line);
+    if (versionHeading) {
+      if (current) {
+        releases.push(current);
+      }
+      current = { heading: versionHeading[1], body: [] };
+      continue;
+    }
+
+    if (/^#\s+/.test(line)) {
+      continue; // Page title comes from SITE_TITLE, not the markdown H1.
+    }
+
+    if (current) {
+      current.body.push(line);
+    } else {
+      intro.push(line);
+    }
+  }
+
+  if (current) {
+    releases.push(current);
+  }
+
+  return {
+    intro: intro.join('\n').trim(),
+    releases: releases.map(toRelease),
+  };
+}
+
+const MONTHS = [
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+];
+
+/** Parses "22 July, 2026" without relying on locale-dependent Date parsing. */
+function parseReleaseDate(text) {
+  const match = /^(\d{1,2})\s+([A-Za-z]+),?\s+(\d{4})$/.exec(text.trim());
+  if (!match) {
+    return null;
+  }
+
+  const monthIndex = MONTHS.indexOf(match[2].toLowerCase());
+  if (monthIndex === -1) {
+    return null;
+  }
+
+  return new Date(Date.UTC(Number(match[3]), monthIndex, Number(match[1])));
+}
+
+function toRelease({ heading, body }) {
+  const versionMatch = /^Version\s+(\S+)\s*(?:[-–—]\s*(.+))?$/.exec(heading);
+  const version = versionMatch ? versionMatch[1] : heading;
+  const dateText = versionMatch && versionMatch[2] ? versionMatch[2].trim() : '';
+  const date = dateText ? parseReleaseDate(dateText) : null;
+  const markdown = body.join('\n').trim();
+
+  return {
+    id: `v-${slugify(version)}`,
+    version,
+    dateText,
+    date,
+    year: date ? String(date.getUTCFullYear()) : '',
+    markdown,
+    html: marked.parse(markdown),
+  };
+}
+
+function renderRelease(release, isLatest) {
+  const latestBadge = isLatest ? '<span class="badge">Latest</span>' : '';
+  const date = release.dateText
+    ? `<time class="release__date"${
+        release.date ? ` datetime="${release.date.toISOString().slice(0, 10)}"` : ''
+      }>${escapeHtml(release.dateText)}</time>`
+    : '';
+
+  return `
+        <article class="release" id="${release.id}" data-version="${escapeHtml(release.version)}">
+          <header class="release__header">
+            <h2 class="release__title">
+              <a class="release__anchor" href="#${release.id}" aria-label="Link to version ${escapeHtml(
+                release.version,
+              )}">#</a>
+              Version ${escapeHtml(release.version)}
+              ${latestBadge}
+            </h2>
+            ${date}
+          </header>
+          <div class="release__body">
+${release.html.trim()}
+          </div>
+        </article>`;
+}
+
+function renderNav(releases) {
+  const groups = [];
+  for (const release of releases) {
+    const label = release.year || 'Earlier releases';
+    const last = groups.at(-1);
+    if (last && last.label === label) {
+      last.releases.push(release);
+    } else {
+      groups.push({ label, releases: [release] });
+    }
+  }
+
+  return groups
+    .map(
+      (group) => `
+          <div class="nav__group">
+            <h3 class="nav__group-title">${escapeHtml(group.label)}</h3>
+            <ul class="nav__list">
+${group.releases
+  .map(
+    (release) => `              <li class="nav__item" data-target="${release.id}">
+                <a href="#${release.id}">
+                  <span class="nav__version">${escapeHtml(release.version)}</span>
+                  ${release.dateText ? `<span class="nav__date">${escapeHtml(release.dateText)}</span>` : ''}
+                </a>
+              </li>`,
+  )
+  .join('\n')}
+            </ul>
+          </div>`,
+    )
+    .join('\n');
+}
+
+function renderPage({ intro, releases }) {
+  const introHtml = intro ? marked.parse(intro) : '';
+
+  return `<!DOCTYPE html>
+<html lang="en" data-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Changelog · ${escapeHtml(SITE_TITLE)}</title>
+    <meta name="description" content="${escapeHtml(SITE_DESCRIPTION)}" />
+    <meta property="og:title" content="Changelog · ${escapeHtml(SITE_TITLE)}" />
+    <meta property="og:description" content="${escapeHtml(SITE_DESCRIPTION)}" />
+    <meta property="og:type" content="website" />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%230078d4'/%3E%3Cpath d='M9 21V11h4.4a3.3 3.3 0 0 1 0 6.6H12V21z' fill='white'/%3E%3C/svg%3E" />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#content">Skip to content</a>
+    <header class="masthead">
+      <div class="masthead__inner">
+        <div class="masthead__brand">
+          <p class="masthead__eyebrow">${escapeHtml(SITE_TITLE)}</p>
+          <h1 class="masthead__title">Changelog</h1>
+        </div>
+        <div class="masthead__actions">
+          <a class="button button--primary" href="${MARKETPLACE_URL}">Get the extension</a>
+          <a class="button" href="${REPO_URL}">GitHub repo</a>
+          <button class="button button--icon" type="button" id="theme-toggle" aria-label="Toggle color theme">
+            <span aria-hidden="true" data-theme-icon>◐</span>
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <div class="layout">
+      <nav class="sidebar" aria-label="Releases">
+        <label class="search" for="search">
+          <span class="visually-hidden">Filter releases</span>
+          <input
+            id="search"
+            type="search"
+            placeholder="Filter releases…"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </label>
+        <p class="sidebar__empty" id="nav-empty" hidden>No matching releases.</p>
+        <div class="nav" id="nav">
+${renderNav(releases)}
+        </div>
+      </nav>
+
+      <main class="content" id="content">
+        ${introHtml ? `<section class="intro">${introHtml}</section>` : ''}
+        <p class="results" id="results" hidden></p>
+${releases.map((release, index) => renderRelease(release, index === 0)).join('\n')}
+        <p class="content__empty" id="content-empty" hidden>
+          No releases match your filter.
+        </p>
+      </main>
+    </div>
+
+    <footer class="footer">
+      <p>
+        Generated from
+        <a href="${REPO_URL}/blob/main/WHATS_NEW.md">WHATS_NEW.md</a>.
+        © Microsoft Corporation.
+      </p>
+    </footer>
+
+    <script src="./app.js"></script>
+  </body>
+</html>
+`;
+}
+
+/**
+ * Clears the output directory's contents rather than the directory itself, so a
+ * local preview server holding it open doesn't fail the build on Windows.
+ */
+async function emptyDir(dir) {
+  await mkdir(dir, { recursive: true });
+  const entries = await readdir(dir);
+  await Promise.all(entries.map((entry) => rm(join(dir, entry), { recursive: true, force: true })));
+}
+
+async function main() {
+  if (!existsSync(sourceFile)) {
+    throw new Error(`Changelog source not found: ${sourceFile}`);
+  }
+
+  const markdown = await readFile(sourceFile, 'utf8');
+  const parsed = parseChangelog(markdown);
+
+  if (parsed.releases.length === 0) {
+    throw new Error('No "## Version ..." sections found in WHATS_NEW.md');
+  }
+
+  await emptyDir(outDir);
+  await writeFile(join(outDir, 'index.html'), renderPage(parsed), 'utf8');
+  await cp(join(siteDir, 'assets'), outDir, { recursive: true });
+  // Pages would otherwise run the output through Jekyll, which drops files
+  // and folders that start with an underscore.
+  await writeFile(join(outDir, '.nojekyll'), '', 'utf8');
+
+  console.log(`Built ${parsed.releases.length} releases -> ${join(outDir, 'index.html')}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "foundry-toolkit-changelog-site",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "foundry-toolkit-changelog-site",
+      "version": "1.0.0",
+      "dependencies": {
+        "marked": "^15.0.7"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha1-MHIsc0bhLQotAgermwxPAQLYbE4=",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    }
+  }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "foundry-toolkit-changelog-site",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Static changelog site generated from WHATS_NEW.md and published to GitHub Pages.",
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs"
+  },
+  "dependencies": {
+    "marked": "^15.0.7"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a static changelog page generated from `WHATS_NEW.md` and published to GitHub Pages.

`WHATS_NEW.md` stays the single source of truth — releases are still edited there, and nothing is duplicated. `site/build.mjs` splits the markdown on each `## Version <version> - <date>` heading and renders a single `index.html`.

## What's included

| File | Purpose |
|---|---|
| `site/build.mjs` | Parses `WHATS_NEW.md`, renders release bodies with `marked`, emits `dist/` |
| `site/assets/styles.css` | Light/dark theme, release cards, sticky version sidebar |
| `site/assets/app.js` | Filter (press `/`), scroll-spy nav highlighting, theme toggle |
| `site/package.json`, `README.md`, `.gitignore` | Build script and docs; `dist/` and `node_modules/` ignored |
| `.github/workflows/publish-changelog.yml` | Builds and deploys to Pages |

The workflow runs on pushes to `main` that touch `WHATS_NEW.md` or `site/`, plus manual dispatch. It uses the `pages`/`id-token` permissions only on the deploy job, and a `pages` concurrency group so queued runs wait rather than cancelling mid-deploy.

## Verification

- `npm run build` parses all 58 releases and emits `index.html`, `styles.css`, `app.js`, `.nojekyll`
- Served locally and confirmed the page, assets, sidebar, filtering, and "Latest" badge all render correctly

## One-time setup after merge

In **Settings → Pages**, set **Source** to **GitHub Actions**. The workflow can't deploy until then. Once the site is live, the root `README.md` can link to it.