### PR TITLE
chore: omit registry URLs from site lockfile

### DIFF
--- a/site/.npmrc
+++ b/site/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -13,7 +13,6 @@
     },
     "node_modules/marked": {
       "version": "15.0.12",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/marked/-/marked-15.0.12.tgz",
       "integrity": "sha1-MHIsc0bhLQotAgermwxPAQLYbE4=",
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
## Summary

Adds `site/.npmrc` with `omit-lockfile-registry-resolved=true` and regenerates the site lockfile so registry feed URLs are not committed.

The regenerated lockfile removes one `resolved` field. Dependency names, versions, integrity hashes, and platform metadata are unchanged.

## Validation

- `npx --yes -p node@20 -p npm@10.9.4 -c 'node --version && npm --version && npm config get omit-lockfile-registry-resolved'` returned Node `v20.20.2`, npm `10.9.4`, and `true`.
- A structural lockfile comparison found no changes outside `resolved`; no Microsoft feed URLs remain.
- Repeating `npm install --package-lock-only --ignore-scripts --no-audit --no-fund` left SHA-256 `9545aba9ebf0447f8c8aa9626851170184d97bf36b73bba7b9091204e8559734` unchanged.
- `npm ci --no-audit --no-fund` installed one package.
- `npm run build` passed and built 61 releases into `site/dist/index.html`.
